### PR TITLE
Adding support for ES6 Promises

### DIFF
--- a/highland.js
+++ b/highland.js
@@ -2515,6 +2515,28 @@
     };
 
     /**
+     * Converts a promise into a stream to support compatibility with promise
+     * based libraries.
+     *
+     * @id fromPromise
+     * @section Utils
+     * @name _.fromPromise(promise)
+     * @param  {Promise} promise - The A+ promise to convert
+     * @api public
+     */
+    _.fromPromise = function(promise) {
+        return _(function (push) {
+            promise.then(function(value) {
+                push(null, value);
+                return push(null, nil);
+            }, function(err) {
+                push(err);
+                return push(null, nil);
+            });
+        });
+    };
+
+    /**
      * Add two values. Can be partially applied.
      *
      * @id add

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "grunt-gh-pages": "~0.9.0",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-contrib-nodeunit": "~0.3.0"
+    "grunt-contrib-nodeunit": "~0.3.0",
+    "es6-promise": "~0.1.1"
   },
   "scripts": {
     "test": "node node_modules/.bin/nodeunit test.js"

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var EventEmitter = require('events').EventEmitter,
     streamify = require('stream-array'),
     concat = require('concat-stream'),
+    Promise = require('es6-promise').Promise,
     _ = require('./highland');
 
 
@@ -2316,6 +2317,22 @@ exports['wrapCallback - errors'] = function (test) {
     };
     test.throws(function () {
         _.wrapCallback(f)(1, 2).toArray(function () {
+            test.ok(false, "this shouldn't be called");
+        });
+    });
+    test.done();
+};
+
+exports['fromPromise'] = function (test) {
+    _.fromPromise(Promise.resolve(3)).toArray(function (xs) {
+        test.same(xs, [3]);
+        test.done();
+    });
+};
+
+exports['fromPromise - errors'] = function (test) {
+    test.throws(function () {
+        _.fromPromise(Promise.reject(new Error('boom'))).toArray(function () {
             test.ok(false, "this shouldn't be called");
         });
     });


### PR DESCRIPTION
It would be nice to be able to convert a promise to a stream as well as
a callback.
