### PR TITLE
Add #compact method

### DIFF
--- a/highland.js
+++ b/highland.js
@@ -1620,7 +1620,7 @@
      * @name Stream.compact()
      * @api public
      *
-     * var compacted = _([1, false, 3, null, undefined, 6]).compact();
+     * var compacted = _([0, 1, false, 3, null, undefined, 6]).compact();
      * // => [1, 3, 6]
      */
 

--- a/test.js
+++ b/test.js
@@ -1668,14 +1668,14 @@ exports['flatFilter - GeneratorStream'] = function (test) {
 
 exports['compact'] = function (test) {
     test.expect(1);
-    _.compact([1, false, 3, undefined, null, 6]).toArray(function (xs) {
+    _.compact([0, 1, false, 3, undefined, null, 6]).toArray(function (xs) {
         test.same(xs, [1, 3, 6]);
     });
     test.done();
 };
 
 exports['compact - ArrayStream'] = function (test) {
-    _([1, false, 3, undefined, null, 6]).compact().toArray(function (xs) {
+    _([0, 1, false, 3, undefined, null, 6]).compact().toArray(function (xs) {
         test.same(xs, [1, 3, 6]);
         test.done();
     });


### PR DESCRIPTION
Solves #17.

Note that this filters out the usual `undefined` and `null`, but also `false` and `0`.

Is this genuinely the expected behaviour though?

In the Ruby world, `#compact` would only filter out "non-values" (`nil`) but retain values like `false` or `0`, e.g.:

```
$ irb
> [1, 2, nil, 0, 3, true, false].compact
 => [1, 2, 0, 3, true, false]
```
