### PR TITLE
TST: Test cases for _.nil

### DIFF
--- a/test.js
+++ b/test.js
@@ -91,6 +91,20 @@ exports['seq'] = function (test) {
 }
 
 /***** Streams *****/
+exports['nil defines end'] = function (test) {
+    _([1,_.nil,3]).toArray(function (xs) {
+        test.same(xs, [1]);
+        test.done();
+    });
+};
+
+exports['nil should not equate to any empty object'] = function (test) {
+    var s = [1,{},3];
+    _(s).toArray(function (xs) {
+        test.same(xs, s);
+        test.done();
+    });
+};
 
 exports['async consume'] = function (test) {
     _([1,2,3,4]).consume(function (err, x, push, next) {


### PR DESCRIPTION
A quick add of test cases for nil, as it was not _immediately_ obvious to me whether highland correctly handles passing empty objects (`{}`) in its streams. 
