### PR TITLE
TST: Travis CI for automated node testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.8"
+  - "0.10"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The high-level streams library for Node.js and the browser.
 View the [Highland website](http://highlandjs.org) for more in-depth
 documentation.
 
+[![build status](https://secure.travis-ci.org/eshao/highland.png)](http://travis-ci.org/eshao/highland)
+
 ## Introduction
 
 Re-thinking the [JavaScript](http://underscorejs.org)


### PR DESCRIPTION
To enable Travis CI, simply register on their site, flip the ON switch for caolan/highland and then change the README.md from eshao/highland to caolan/highland. 

I also looked into two solutions for automated cross-browser testing. Both zuul and testling generally require mocha or tape as the test producer for _drop-in_ integration. If we put a bit of work into it, I guess we can make it work with nodeunit. However, I think we should do it as proving which browser versions we're compatible with is better than simply saying we're "browser compatible."
