### PR TITLE
in-browser testing, testling and test running instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 /node_modules
 /.grunt
+test/browser.js

--- a/Contributing.md
+++ b/Contributing.md
@@ -25,6 +25,25 @@ Code changes
 6. Send a pull request \o/
 
 
+Running the tests
+------------
+
+To run the linter and nodeunit tests in Node.js, use the grunt task:
+
+    grunt test
+
+To run tests in a browser, first build the browser-test bundle.
+
+    grunt browserify:test-browser
+    # now visit test/browser.html in your browser
+
+The package.json has also been set-up to run tests with testling, localy this
+will use whatever headless browser it can find on your system.
+
+    npm install -g testling
+    testling
+
+
 Editing docs
 ------------
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,18 +16,28 @@ module.exports = function (grunt) {
         },
 
         browserify: {
-            all: {
+            main: {
                 files: {
                     'dist/highland.js': ['lib/index.js']
                 },
                 options: {
                     standalone: 'highland'
                 }
+            },
+            'test-browser': {
+                files: {
+                    'test/browser.js': ['test/testling.js']
+                },
+                options: {
+                    ignore: [
+                        './node_modules/nodeunit/lib/reporters/index.js'
+                    ]
+                }
             }
         },
 
         nodeunit: {
-            all: ['test.js']
+            all: ['test/test.js']
         },
 
         watch: {
@@ -56,6 +66,6 @@ module.exports = function (grunt) {
     grunt.loadTasks('./tasks');
 
     grunt.registerTask('test', ['jshint:all', 'nodeunit:all']);
-    grunt.registerTask('default', ['browserify', 'docs']);
+    grunt.registerTask('default', ['browserify:main', 'docs']);
 
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/caolan/highland.git"
   },
   "devDependencies": {
-    "nodeunit": "~0.8.1",
+    "nodeunit": "~0.8.6",
     "stream-array": "~0.1.3",
     "concat-stream": "~1.4.1",
     "scrawl": "0.0.5",
@@ -23,9 +23,23 @@
     "grunt-contrib-nodeunit": "~0.3.0",
     "es6-promise": "~0.1.1",
     "browserify": "~3.30.1",
-    "grunt-browserify": "~1.3.1"
+    "grunt-browserify": "~1.3.1",
+    "nodeunit-tape": "^0.2.0"
   },
   "scripts": {
-    "test": "nodeunit test.js"
+    "test": "nodeunit test/test.js"
+  },
+  "testling": {
+    "files": "test/testling.js",
+    "browsers": [
+      "ie/8..latest",
+      "chrome/latest",
+      "firefox/latest",
+      "safari/latest",
+      "opera/latest",
+      "iphone/latest",
+      "ipad/latest",
+      "android-browser/latest"
+    ]
   }
 }

--- a/test/browser.html
+++ b/test/browser.html
@@ -1,0 +1,16 @@
+<script src="./browser.js"></script>
+<script>
+if (!window.testsuiteLoaded) {
+    document.write('<h1>ERROR: ./browser.js not found</h1>');
+}
+</script>
+
+<h1>Open the dev console to see results</h1>
+
+<hr />
+
+<h3>TODO</h3>
+<ul>
+<li>test <kbd>dist/highland.js</kbd> instead of the testling bundle</li>
+<li>Have the formatter output to the DOM</li>
+</ul>

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ var EventEmitter = require('events').EventEmitter,
     streamify = require('stream-array'),
     concat = require('concat-stream'),
     Promise = require('es6-promise').Promise,
-    _ = require('./lib/index');
+    _ = require('../lib/index');
 
 
 /**

--- a/test/testling.js
+++ b/test/testling.js
@@ -1,0 +1,9 @@
+global.testsuiteLoaded = true;
+
+var nodeunit = require('nodeunit-tape');
+
+var tests = {
+    'highland': require('./test.js')
+};
+
+nodeunit.run(tests);


### PR DESCRIPTION
This isn't completely polished - but does work as documented in the section i've added to the bottom of the ReadMe

Mostly just putting up for some peer review at this stage

The testsuite may need to have the node-only tests split out (process.stdout/stderr fail in firefox at the mo for example)
