### PR TITLE
Add npm metadata: files, homepage, bugs, and repository.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "1.8.1",
   "description": "The high-level streams library",
   "main": "lib/index.js",
+  "files": ["lib"],
+  "homepage": "http://highlandjs.org/",
+  "bugs": "https://github.com/caolan/highland/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/caolan/highland.git"
+  },
   "devDependencies": {
     "nodeunit": "~0.8.1",
     "stream-array": "~0.1.3",


### PR DESCRIPTION
Following the guidance of the [package.json](https://www.npmjs.org/doc/files/package.json.html) docs, I've added a few keys to improve package discoverability and tarball size.
- `files`: When employed as an npm dependency, we only want the lib code. There's currently a lot of extra stuff included in the package downloaded from npm (docs, test, dev metadata files, "callbackhell.js", etc).
- `repository`: Removes "No repository field" warning when installing.
- `homepage`: Makes `npm home highland` and `npm docs highland` open the correct page (highlandjs.org).
- `bugs`: Makes `npm bugs highland` open the appropriate page (GitHub Issues)

`homepage`, `bugs`, and `repository` also add useful links to the header of highland's [npmjs.org homepage](https://www.npmjs.org/package/highland).
