### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "highland",
+  "version": "1.8.1",
+  "homepage": "https://github.com/caolan/highland",
+  "authors": [
+    "Caolan McMahon"
+  ],
+  "description": "The high-level streams library.",
+  "main": "dist/highland.js",
+  "keywords": [
+    "streams",
+    "async",
+    "events",
+    "pipe"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "Contributing.md",
+    "Gruntfile.js",
+    "bench",
+    "docs",
+    "node_modules",
+    "bower_components",
+    "tasks",
+    "test.js",
+    "test"
+  ]
+}


### PR DESCRIPTION
[Bower](http://bower.io) is a package manager for browser components. It should help streamline the browser usage of highland, while not prohibiting manual installation via git clone.

If this is accepted, you would need to register the module:

``` bash
npm -g install bower
# in the highland root directory
bower register highland https://github.com/caolan/highland.git
```

It does unfortunately encumber another `version` property to bump during releases, but that could be automated via Grunt (perhaps via [grunt-release](https://github.com/geddski/grunt-release)?).
