### PR TITLE
Adds Stream::destroy() which ends the stream and cleans up emitters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -316,6 +316,7 @@ function Stream(/*optional*/xs, /*optional*/ee) {
     this._outgoing = [];
     this._consumers = [];
     this._observers = [];
+    this._destructors = [];
     this._send_events = false;
 
     self.on('newListener', function (ev) {
@@ -690,12 +691,53 @@ Stream.prototype.pipe = function (dest) {
             next();
         }
     });
-    dest.on('drain', function () {
-        s.resume();
+
+    dest.on('drain', onConsumerDrain);
+
+    // Since we don't keep a reference to piped-to streams,
+    // save a callback that will unbind the event handler.
+    this._destructors.push(function () {
+        dest.removeListener('drain', onConsumerDrain);
     });
+
     s.resume();
     return dest;
+
+    function onConsumerDrain () {
+        s.resume();
+    }
 };
+
+/**
+ * Destroys a stream by unlinking it from any consumers and sources. This will
+ * stop all consumers from receiving events from this stream and removes this
+ * stream as a consumer of any source stream.
+ *
+ * This function calls end() on the stream and unlinks it from any piped-to streams.
+ *
+ * @id pipe
+ * @section Streams
+ * @name Stream.destroy()
+ * @api public
+ */
+
+Stream.prototype.destroy = function () {
+    var self = this;
+
+    this.end();
+
+    _(this._consumers).each(function (consumer) {
+        self._removeConsumer(consumer);
+    });
+
+    if (this.source) {
+        this.source._removeConsumer(this);
+    }
+
+    _(this._destructors).each(function (destructor) {
+        destructor();
+    });
+}
 
 /**
  * Runs the generator function for this Stream. If the generator is already


### PR DESCRIPTION
This provides a mechanism to allow code to 'stop using' a highland stream. For example, in cases where a temporary stream should be piped to another stream, this method allows you to break that link and clean up dangling references.

See #37.
