### PR TITLE
Handle piping from old-style node streams

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -333,6 +333,10 @@ function Stream(/*optional*/xs, /*optional*/ee) {
     this._observers = [];
     this._destructors = [];
     this._send_events = false;
+    this.source = null;
+
+    // Old-style node Stream.pipe() checks for this
+    this.writable = true;
 
     self.on('newListener', function (ev) {
         if (ev === 'data') {


### PR DESCRIPTION
As mentioned in http://stackoverflow.com/questions/21954125/the-request-stream-in-highland-is-not-correctly-passed-forward

The request() module uses a sort-of old-style stream.

https://github.com/mikeal/request/blob/11224dd1f02e311afcc11df8a8f0be1d9fb2bf83/request.js#L1310

I traced this down to the following check https://github.com/joyent/node/blob/dbae8b569fd1afa04cddac47b30379e4ebf3388a/lib/stream.js#L50 - I'm unsure whether this should really be a loud error, will probably report to Node.js core.

I was unsure whether a stream that had been given a different source should be considered writable, but decided to just flag everything as writable and leave it to users to not do anything weird - open to alternative perspectives on that.
