### PR TITLE
Add #merge method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2134,8 +2134,8 @@ Stream.prototype.concat = function (ys) {
 exposeMethod('concat');
 
 /**
- * Merge values and errors from this Stream with those from another
- * Stream.  The merged stream ends when both streams have ended.
+ * Takes a Stream of Streams and merge their values and errors into a
+ * new Stream.  The merged stream ends when both streams have ended.
  *
  * Note that no guarantee is made with respect to the order in which
  * values for each stream end up in the merged stream. Values in the
@@ -2144,28 +2144,25 @@ exposeMethod('concat');
  *
  * @id merge
  * @section Streams
- * @name Stream.merge(ys)
- * @params {Stream | Array} ys - the values to merge with this Stream
+ * @name Stream.merge()
  * @api public
  *
  * var txt = _(['foo.txt', 'bar.txt']).map(readFile)
  * var md = _(['baz.md']).map(readFile)
- * txt.merge(md); // => stream of contents of foo.txt, bar.txt and baz.txt
- *                //    in the order they were read
+ * _([txt, md]).merge(); // => stream of contents of foo.txt, bar.txt
+ *                       //    and baz.txt in the order they were read
  */
 
-Stream.prototype.merge = function (ys) {
-    ys = _(ys);
-    var xs = this;
+Stream.prototype.merge = function () {
+    var self = this;
     var nilCount = 0;
-    var pulling = [];
-    function nextValue(index, src, push, next) {
-        pulling[index] = true;
+    var streamCount = 0;
+    function nextValue (src, push, next) {
         src.pull(function (err, x) {
             if (x === _.nil) {
                 nilCount++;
-                // end merged stream when both ended
-                if (nilCount === 2) {
+                // end merged stream when all ended
+                if (self.ended && nilCount === streamCount) {
                     push(null, nil);
                 }
             }
@@ -2173,16 +2170,20 @@ Stream.prototype.merge = function (ys) {
                 // pass through values from either input stream
                 push(err, x);
             }
-            pulling[index] = false;
             next();
+            // pull next value from this source
+            nextValue(src, push, next);
         });
     }
     return _(function (push, next) {
-        if (! pulling[0] && !xs.ended) {
-            nextValue(0, xs, push, next);
-        }
-        if (! pulling[1] && !ys.ended) {
-            nextValue(1, ys, push, next);
+        if (! self.ended) {
+            self.pull(function (err, src) {
+                if (src !== _.nil) {
+                    streamCount++;
+                    // start pulling values from this stream
+                    nextValue(src, push, next);
+                }
+            });
         }
     });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1481,21 +1481,60 @@ exports['concat - GeneratorStream'] = function (test) {
     });
 };
 
-exports['merge'] = function (test) {
-    test.expect(2);
-    _.merge([3,4], [1,2]).toArray(function (xs) {
-        test.same(xs, [1,3,2,4]);
+exports['merge - ArrayStream'] = function (test) {
+    var s1 = _(function (push, next) {
+        push(null, 1);
+        setTimeout(function () {
+            push(null, 2);
+        }, 20);
+        setTimeout(function () {
+            push(null, 3);
+            push(null, _.nil);
+        }, 40);
     });
-    // partial application
-    _.merge([3,4])([1,2]).toArray(function (xs) {
-        test.same(xs, [1,3,2,4]);
+    var s2 = _(function (push, next) {
+        setTimeout(function () {
+            push(null, 4);
+        }, 10);
+        setTimeout(function () {
+            push(null, 5);
+        }, 30);
+        setTimeout(function () {
+            push(null, 6);
+            push(null, _.nil);
+        }, 50);
     });
-    test.done();
+    _.merge([s1, s2]).toArray(function (xs) {
+        test.same(xs, [1,4,2,5,3,6]);
+        test.done();
+    });
 };
 
 exports['merge - ArrayStream'] = function (test) {
-    _([1,2]).merge([3,4]).toArray(function (xs) {
-        test.same(xs, [1,3,2,4]);
+    var s1 = _(function (push, next) {
+        push(null, 1);
+        setTimeout(function () {
+            push(null, 2);
+        }, 20);
+        setTimeout(function () {
+            push(null, 3);
+            push(null, _.nil);
+        }, 40);
+    });
+    var s2 = _(function (push, next) {
+        setTimeout(function () {
+            push(null, 4);
+        }, 10);
+        setTimeout(function () {
+            push(null, 5);
+        }, 30);
+        setTimeout(function () {
+            push(null, 6);
+            push(null, _.nil);
+        }, 50);
+    });
+    _([s1, s2]).merge().toArray(function (xs) {
+        test.same(xs, [1,4,2,5,3,6]);
         test.done();
     });
 };
@@ -1523,7 +1562,15 @@ exports['merge - GeneratorStream'] = function (test) {
             push(null, _.nil);
         }, 50);
     });
-    s1.merge(s2).toArray(function (xs) {
+    var s = _(function (push, next) {
+        push(null, s1);
+
+        setTimeout(function() {
+            push(null, s2);
+            push(null, _.nil);
+        }, 5);
+    });
+    s.merge().toArray(function (xs) {
         test.same(xs, [1,4,2,5,3,6]);
         test.done();
     });


### PR DESCRIPTION
I wanted a way to merge two streams, similarly to `concat` but without having to wait for the first one to end to start consuming the second one. This would be useful when you don't care about the order values are pulled from each stream into the merged stream (although the partial order of each input stream is respected).

I must say I'm not sure how this related to `parallel`, or the `merge` evoked in #30, but I thought I'd submit the code I got to work for feedback.
