### PR TITLE
Don't start reducing in reduce1 when encountered error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2063,7 +2063,7 @@ Stream.prototype.reduce1 = function (f) {
                 push(err);
                 next();
             }
-            if (x === nil) {
+            else if (x === nil) {
                 push(null, nil);
             }
             else {

--- a/test/test.js
+++ b/test/test.js
@@ -1379,6 +1379,28 @@ exports['reduce1 - GeneratorStream'] = function (test) {
     });
 };
 
+exports['reduce1 - GeneratorStream - pass errors through'] = function (test) {
+    test.expect(2);
+    function add(a, b) {
+        return a + b;
+    }
+    var s = _(function (push, next) {
+        setTimeout(function () {
+            push('fail');
+            push(null, 1);
+            push(null, 2);
+            push(null, _.nil);
+        }, 10);
+    });
+    s.reduce1(add).errors(function(error) {
+        test.same(error, 'fail');
+        // swallow error
+    }).toArray(function (xs) {
+        test.same(xs, [3]);
+        test.done();
+    });
+};
+
 
 exports['scan'] = function (test) {
     test.expect(3);


### PR DESCRIPTION
See test case.

I can't think that calling `next` when pulling an error is intended?
