### PR TITLE
fix id so destroy shows up in the navigation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -753,7 +753,7 @@ Stream.prototype.pipe = function (dest) {
  *
  * This function calls end() on the stream and unlinks it from any piped-to streams.
  *
- * @id pipe
+ * @id destroy
  * @section Streams
  * @name Stream.destroy()
  * @api public


### PR DESCRIPTION
currently, pipe was linked twice, but destroy wasn't
