### PR TITLE
Support of pack()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1673,19 +1673,19 @@ Stream.prototype.zip = function (ys) {
 exposeMethod('zip');
 
 /**
- * Takes one Stream and packs incoming data into arrays of given length
+ * Takes one Stream and batches incoming data into arrays of given length
  *
- * @id pack
+ * @id batch
  * @section Streams
- * @name Stream.pack(n)
- * @param {Number} n - length of the array to pack
+ * @name Stream.batch(n)
+ * @param {Number} n - length of the array to batch
  * @api public
  *
- * _([1, 2, 3, 4, 5]).pack(2)  // => [1, 2], [3, 4], [5]
+ * _([1, 2, 3, 4, 5]).batch(2)  // => [1, 2], [3, 4], [5]
  */
 
-Stream.prototype.pack = function (n) {
-    var packed = [];
+Stream.prototype.batch = function (n) {
+    var batched = [];
 
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -1693,24 +1693,24 @@ Stream.prototype.pack = function (n) {
             next();
         }
         if (x === nil) {
-            if (packed.length > 0) {
-                push(null, packed);
+            if (batched.length > 0) {
+                push(null, batched);
             }
 
             push(null, nil);
         } else {
-            packed.push(x);
+            batched.push(x);
 
-            if (packed.length === n) {
-                push(null, packed);
-                packed = [];
+            if (batched.length === n) {
+                push(null, batched);
+                batched = [];
             }
 
             next();
         }
     });
 };
-exposeMethod('pack');
+exposeMethod('batch');
 
 /**
  * Creates a new Stream with the first `n` values from the source.

--- a/test/test.js
+++ b/test/test.js
@@ -2439,57 +2439,57 @@ exports['zip - GeneratorStream'] = function (test) {
     });
 };
 
-exports['pack'] = function (test) {
+exports['batch'] = function (test) {
     test.expect(5);
-    _.pack(3, [1,2,3,4,5,6,7,8,9,0]).toArray(function (xs) {
+    _.batch(3, [1,2,3,4,5,6,7,8,9,0]).toArray(function (xs) {
         test.same(xs, [[1,2,3], [4,5,6], [7,8,9], [0]]);
     });
 
-    _.pack(3, [1,2,3]).toArray(function (xs) {
+    _.batch(3, [1,2,3]).toArray(function (xs) {
         test.same(xs, [[1,2,3]]);
     });
 
-    _.pack(2, [1,2,3]).toArray(function (xs) {
+    _.batch(2, [1,2,3]).toArray(function (xs) {
         test.same(xs, [[1,2],[3]]);
     });
 
-    _.pack(1, [1,2,3]).toArray(function (xs) {
+    _.batch(1, [1,2,3]).toArray(function (xs) {
         test.same(xs, [[1],[2],[3]]);
     });
 
-    _.pack(0, [1,2,3]).toArray(function (xs) {
+    _.batch(0, [1,2,3]).toArray(function (xs) {
         test.same(xs, [[1,2,3]]);
     });
 
     test.done();
 };
 
-exports['pack - ArrayStream'] = function (test) {
+exports['batch - ArrayStream'] = function (test) {
     test.expect(5);
-    _([1,2,3,4,5,6,7,8,9,0]).pack(3).toArray(function (xs) {
+    _([1,2,3,4,5,6,7,8,9,0]).batch(3).toArray(function (xs) {
         test.same(xs, [[1,2,3], [4,5,6], [7,8,9], [0]]);
     });
 
-    _([1,2,3]).pack(4).toArray(function (xs) {
+    _([1,2,3]).batch(4).toArray(function (xs) {
         test.same(xs, [[1,2,3]]);
     });
 
-    _([1,2,3]).pack(2).toArray(function (xs) {
+    _([1,2,3]).batch(2).toArray(function (xs) {
         test.same(xs, [[1,2],[3]]);
     });
 
-    _([1,2,3]).pack(1).toArray(function (xs) {
+    _([1,2,3]).batch(1).toArray(function (xs) {
         test.same(xs, [[1],[2],[3]]);
     });
 
-    _([1,2,3]).pack(0).toArray(function (xs) {
+    _([1,2,3]).batch(0).toArray(function (xs) {
         test.same(xs, [[1,2,3]]);
     });
 
     test.done();
 };
 
-exports['pack - GeneratorStream'] = function (test) {
+exports['batch - GeneratorStream'] = function (test) {
     var s1 = _(function (push, next) {
         push(null, 1);
         setTimeout(function () {
@@ -2500,7 +2500,7 @@ exports['pack - GeneratorStream'] = function (test) {
             }, 10);
         }, 10);
     });
-    s1.pack(1).toArray(function (xs) {
+    s1.batch(1).toArray(function (xs) {
         test.same(xs, [[1], [2], [3]]);
         test.done();
     });


### PR DESCRIPTION
`pack` is algorithm able to,

``` js
_([1, 2, 3, 4, 5]).pack(2)  // => [1, 2], [3, 4], [5]
```

recently I've been impletementing one [tool](https://github.com/likeastore/elaster) for streaming mongodb collection to elastic search index.. mongo collection is streamed and each record pushed to elastic search. that appeared to be quite slow on big collections. ES provides bulk indexing, which mitigates HTTP overheads a bit. With pack, code will be really nice

``` js
var stream = db.items.find({}).sort({_id: -1}); 
_(stream).pack(128).through(elasticBulk);
```

so, `pack` will be useful for any _bulk_ stream operations.

**PS**. name of function, description could be poor.. but if you see the sense of such function, I'll be happy to discuss.

**PSS**. also thought that `pack()` could be derived from `collect()` with parameter.
