### PR TITLE
Fix sequence for the stream of stream of arrays case.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1950,14 +1950,18 @@ Stream.prototype.sequence = function () {
                 return next();
             }
             else if (_.isArray(x)) {
-                // just send all values from array directly
-                x.forEach(function (y) {
-                    push(null, y);
-                });
+                if (onOriginalStream()) {
+                    // just send all values from array directly
+                    x.forEach(function (y) {
+                        push(null, y);
+                    });
+                } else {
+                    push(null, x);
+                }
                 return next();
             }
             else if (_.isStream(x)) {
-                if (curr === original) {
+                if (onOriginalStream()) {
                     // switch to reading new stream
                     curr = x;
                     return next();
@@ -1969,7 +1973,7 @@ Stream.prototype.sequence = function () {
                 }
             }
             else if (x === nil) {
-                if (curr === original) {
+                if (onOriginalStream()) {
                     push(null, nil);
                 }
                 else {
@@ -1979,7 +1983,7 @@ Stream.prototype.sequence = function () {
                 }
             }
             else {
-                if (curr === original) {
+                if (onOriginalStream()) {
                     // we shouldn't be getting non-stream (or array)
                     // values from the top-level stream
                     push(new Error(
@@ -1994,6 +1998,10 @@ Stream.prototype.sequence = function () {
             }
         });
     });
+
+    function onOriginalStream() {
+        return curr === original;
+    }
 };
 exposeMethod('sequence');
 

--- a/test/test.js
+++ b/test/test.js
@@ -1088,6 +1088,17 @@ exports['sequence - series alias'] = function (test) {
     test.done();
 };
 
+exports['sequence - Streams of Streams of Arrays'] = function (test) {
+    _([
+        _([1,2]),
+        _([3]),
+        _([[4],5])
+    ]).sequence().toArray(function (xs) {
+        test.same(xs, [1,2,3,[4],5]);
+        test.done();
+    });
+}
+
 exports['fork'] = function (test) {
     var s = _([1,2,3,4]);
     s.id = 's';


### PR DESCRIPTION
Sequence does a two-level flatten if you have a Stream of Stream of Arrays. Basically, this test fails:

```
_([
    _([1,2]),
    _([3]),
    _([[4],5])
]).sequence().toArray(function (xs) {
    test.same(xs, [1,2,3,[4],5]);
    test.done();
});
```

It emits `[1,2,3,4,5]` instead.
