### PR TITLE
Support concat of an already-flowing stream

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -450,10 +450,7 @@ function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
         }
         else {
             // assume it's a pipeable stream as a source
-            this._generator = function () {
-                delete self._generator;
-                xs.pipe(self);
-            };
+            xs.pipe(self);
         }
     }
     else if (typeof xs === 'string') {
@@ -2413,6 +2410,7 @@ exposeMethod('scan1');
  */
 
 Stream.prototype.concat = function (ys) {
+    ys = _(ys);
     return this.consume(function (err, x, push, next) {
         if (x === nil) {
             next(ys);

--- a/test/test.js
+++ b/test/test.js
@@ -1671,6 +1671,13 @@ exports['concat - ArrayStream'] = function (test) {
     });
 };
 
+exports['concat - piped ArrayStream'] = function (test) {
+    _.concat(streamify([3,4]).pipe(through()), streamify([1,2])).toArray(function (xs) {
+        test.same(xs, [1,2,3,4]);
+        test.done();
+    });  
+};
+
 exports['concat - GeneratorStream'] = function (test) {
     var s1 = _(function (push, next) {
         setTimeout(function () {


### PR DESCRIPTION
Per your request in issue #87, this pull request adds a test for concat of an already-flowing stream (e.g., concatting an existing pipeline).  Without the changes to `lib/index.js`, the test will fail, by never calling `test.done()`.

All tests (as run by `npm test`) still pass with eager piping, as implemented in this patch.  If there's something that breaks due to eager piping, it's not covered by the tests as far as I can tell.
