### PR TITLE
Implement flatMap with sequence(). Resolves #88.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1329,10 +1329,8 @@ exposeMethod('map');
 
 /**
  * Creates a new Stream of values by applying each item in a Stream to an
- * iterator function which may return a Stream. Each item on these result
- * Streams are then emitted on a single output Stream.
- *
- * The same as calling `stream.map(f).flatten()`.
+ * iterator function which must return a (possibly empty) Stream. Each item on
+ * these result Streams are then emitted on a single output Stream.
  *
  * @id flatMap
  * @section Higher-order Streams
@@ -1344,7 +1342,7 @@ exposeMethod('map');
  */
 
 Stream.prototype.flatMap = function (f) {
-    return this.map(f).flatten();
+    return this.map(f).sequence();
 };
 exposeMethod('flatMap');
 

--- a/test/test.js
+++ b/test/test.js
@@ -2063,6 +2063,17 @@ exports['flatMap - GeneratorStream'] = function (test) {
     });
 };
 
+exports['flatMap - map to Stream of Array'] = function (test) {
+    test.expect(1);
+    var f = function (x) {
+        return _([[x]]);
+    };
+    var s = _([1,2,3,4]).flatMap(f).toArray(function (xs) {
+        test.same(xs, [[1],[2],[3],[4]]);
+        test.done();
+    });
+};
+
 exports['pluck'] = function (test) {
     var a = _([
         {type: 'blogpost', title: 'foo'},


### PR DESCRIPTION
Implement `flatMap` using `sequence` instead of `flatten` per the disscussion in #88.
