### PR TITLE
Revert automatic catching of exception in #stopOnError and #error.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1126,8 +1126,6 @@ Stream.prototype.observe = function () {
  * handler chooses to rethrow them using `push`). Errors can also be
  * transformed and put back onto the Stream as values.
  *
- * If `f` throws an error, then that error will be emitted downstream.
- *
  * @id errors
  * @section Transforms
  * @name Stream.errors(f)
@@ -1149,11 +1147,7 @@ Stream.prototype.observe = function () {
 Stream.prototype.errors = function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
-            try {
-                f(err, push);
-            } catch (e) {
-                push(e);
-            }
+            f(err, push);
             next();
         }
         else if (x === nil) {
@@ -1185,11 +1179,7 @@ exposeMethod('errors');
 Stream.prototype.stopOnError = function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
-            try {
-                f(err, push);
-            } catch (e) {
-                push(e);
-            }
+            f(err, push);
             push(null, nil);
         }
         else if (x === nil) {

--- a/test/test.js
+++ b/test/test.js
@@ -422,27 +422,6 @@ exports['errors - rethrows + forwarding different stream'] = function (test) {
     test.done();
 };
 
-
-exports['errors - argument function throws'] = function (test) {
-    test.expect(4);
-    var err1 = new Error('one');
-    var err2 = new Error('two');
-    var s = _(function (push, next) {
-        push(null, 1);
-        push(err1);
-        push(null, 2);
-        push(null, _.nil);
-    }).errors(function () {
-        throw err2;
-    });
-
-    s.pull(valueEquals(test, 1));
-    s.pull(errorEquals(test, 'two'));
-    s.pull(valueEquals(test, 2));
-    s.pull(valueEquals(test, _.nil));
-    test.done();
-};
-
 exports['errors - ArrayStream'] = function (test) {
     var errs = [];
     var f = function (err, rethrow) {
@@ -521,25 +500,6 @@ exports['stopOnError - rethrows + forwarding different stream'] = function (test
             test.ok(false, 'should not be called');
         });
     }, 'one');
-    test.done();
-};
-
-exports['stopOnError - argument function throws'] = function (test) {
-    test.expect(3);
-    var err1 = new Error('one');
-    var err2 = new Error('two');
-    var s = _(function (push) {
-        push(null, 1);
-        push(err1);
-        push(null, 2);
-        push(null, _.nil);
-    }).stopOnError(function () {
-        throw err2;
-    });
-
-    s.pull(valueEquals(test, 1));
-    s.pull(errorEquals(test, 'two'));
-    s.pull(valueEquals(test, _.nil));
     test.done();
 };
 


### PR DESCRIPTION
My recent pull request to add error handling to certain stream methods (#97) caused a cute regression in how exceptions are propagated.

The auto error handling for `_.stopOnError` and `_.errors` was too aggressive. In certain cases, it caught and suppressed legitimate exceptions (like the one thrown by `_.toArray` on errors) that was not actually caused by the argument function. This is somehow related to using `_.pull` in a different stream (e.g., in `_.sequence`).

Since the user already has a way to signal errors in his error handler (via the second parameter passed to that handler), the simplest way to fix this is to stop catch user exceptions in that case.

One such case is

``` javascript
var s = _(function (push, next) {
    push(new Error(msg));
    push(null, _.nil);
}).errors(function (e, p) { p(e); });

_(function (push, next) {
    s.pull(function (err, val) {
        push(err, val);
        next();
    });
}).toArray(console.log);
```

This code should throw an exception, yet it does nothing.

Moral of the story: be _very_ careful when catching errors.
