### PR TITLE
Docs: clarify the fact that `next()` unlocks calls to the generator func...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,9 +22,12 @@ var EventEmitter = require('events').EventEmitter;
  * **Generators -** These are functions which provide values for the Stream.
  * They are lazy and can be infinite, they can also be asynchronous (for
  * example, making a HTTP request). You emit values on the Stream by calling
- * `push(err, val)`, much like a standard Node.js callback. You call `next()`
- * to signal you've finished processing the current data. If the Stream is
- * still being consumed the generator function will then be called again.
+ * `push(err, val)`, much like a standard Node.js callback. Once it has been
+ * called, the generator function will not be called again unless you call
+ * `next()`. This call to `next()` will signal you've finished processing the
+ * current data and allow for the generator function to be called again. If the
+ * Stream is still being consumed the generator function will then be called
+ * again.
  *
  * You can also redirect a generator Stream by passing a new source Stream
  * to read from to next. For example: `next(other_stream)` - then any subsequent


### PR DESCRIPTION
...tion
## 

I had to look into the source code to check for the guarantee that the generator function cannot be called again until a call to `next()` releases it

If I am correct, this guarantee is by design, and I tried in this PR to make it more clear in the documentation.
