### PR TITLE
Implements done, modifies each to return a stream

### DIFF
--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -185,7 +185,7 @@ var nums = _(['1', '2', '3']).map(function (x) {
 });
 
 // calls === 0</code></pre>
-      <p>To get the map iterator to be called, we must pull some data from the Stream. This is called a <strong><em>thunk</em></strong>, and some Highland methods will cause them (eg, <code>each</code>, <code>apply</code>, <code>toArray</code>, <code>pipe</code>, <code>resume</code>).</p>
+      <p>To get the map iterator to be called, we must pull some data from the Stream. This is called a <strong><em>thunk</em></strong>, and some Highland methods will cause them (eg, <code>each</code>, <code>done</code>, <code>apply</code>, <code>toArray</code>, <code>pipe</code>, <code>resume</code>).</p>
       <pre><code class="javascript">nums.each(function (n) { console.log(n); });
 
 // calls === 3</code></pre>

--- a/lib/index.js
+++ b/lib/index.js
@@ -1363,9 +1363,11 @@ Stream.prototype.each = function (f) {
     var s = this.consume(function (err, x, push, next) {
         if (err) {
             self.emit('error', err);
-        } else if (x === nil) {
+        }
+        else if (x === nil) {
             push(null, nil);
-        } else {
+        }
+        else {
             f(x);
             next();
         }
@@ -1458,15 +1460,17 @@ Stream.prototype.toArray = function (f) {
 Stream.prototype.done = function (f) {
     if (this.ended) {
         f();
-        return;
+        return null;
     }
     var self = this;
     return this.consume(function (err, x, push, next) {
         if (err) {
             self.emit('error', err);
-        } else if (x === nil) {
+        }
+        else if (x === nil) {
             f();
-        } else {
+        }
+        else {
             next();
         }
     }).resume();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1360,15 +1360,18 @@ exposeMethod('stopOnError');
 
 Stream.prototype.each = function (f) {
     var self = this;
-    return this.consume(function (err, x, push, next) {
+    var s = this.consume(function (err, x, push, next) {
         if (err) {
             self.emit('error', err);
-        }
-        else if (x !== nil) {
+        } else if (x === nil) {
+            push(null, nil);
+        } else {
             f(x);
             next();
         }
-    }).resume();
+    });
+    s.resume();
+    return s;
 };
 exposeMethod('each');
 
@@ -1403,7 +1406,7 @@ exposeMethod('apply');
 
 /**
  * Collects all values from a Stream into an Array and calls a function with
- * once with the result. This function causes a **thunk**.
+ * the result. This function causes a **thunk**.
  *
  * If an error from the Stream reaches the `toArray` call, it will emit an
  * error event (which will cause it to throw if unhandled).
@@ -1429,6 +1432,44 @@ Stream.prototype.toArray = function (f) {
             f(x);
         }
     });
+};
+
+/**
+ * Calls a function once the Stream has ended. This function causes a **thunk**.
+ * If the Stream has already ended, the function is called immediately.
+ *
+ * If an error from the Stream reaches the `done` call, it will emit an
+ * error event (which will cause it to throw if unhandled).
+ *
+ * @id done
+ * @section Consumption
+ * @name Stream.done(f)
+ * @param {Function} f - the callback
+ * @api public
+ *
+ * var total = 0;
+ * _([1, 2, 3, 4]).each(function (x) {
+ *     total += x;
+ * }).done(function () {
+ *     // total will be 10
+ * });
+ */
+
+Stream.prototype.done = function (f) {
+    if (this.ended) {
+        f();
+        return;
+    }
+    var self = this;
+    return this.consume(function (err, x, push, next) {
+        if (err) {
+            self.emit('error', err);
+        } else if (x === nil) {
+            f();
+        } else {
+            next();
+        }
+    }).resume();
 };
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -1096,6 +1096,81 @@ exports['each - throw error if consumed'] = function (test) {
     test.done();
 };
 
+exports['done'] = function (test) {
+    test.expect(3);
+
+    var calls = [];
+    _.map(function (x) {
+        calls.push(x);
+        return x;
+    }, [1,2,3]).done(function () {
+        test.same(calls, [1, 2, 3]);
+    });
+
+    calls = [];
+    _.each(function (x) {
+        calls.push(x);
+    }, [1,2,3]).done(function () {
+        test.same(calls, [1,2,3]);
+    });
+
+    // partial application
+    calls = [];
+    _.each(function (x) {
+        calls.push(x);
+    })([1,2,3]).done(function () {
+        test.same(calls, [1,2,3]);
+    });
+
+    test.done();
+}
+
+exports['done - ArrayStream'] = function (test) {
+    var calls = [];
+    _([1,2,3]).each(function (x) {
+        calls.push(x);
+    }).done(function () {
+        test.same(calls, [1,2,3]);
+        test.done();
+    });
+}
+
+exports['done - GeneratorStream'] = function (test) {
+    function delay(push, ms, x) {
+        setTimeout(function () {
+            push(null, x);
+        }, ms);
+    }
+    var source = _(function (push, next) {
+        delay(push, 10, 1);
+        delay(push, 20, 2);
+        delay(push, 30, 3);
+        delay(push, 40, _.nil);
+    });
+
+    var calls = [];
+    source.each(function (x) {
+        calls.push(x);
+    }).done(function () {
+        test.same(calls, [1,2,3]);
+        test.done();
+    })
+}
+
+exports['done - throw error if consumed'] = function (test) {
+    var e = new Error('broken');
+    var s = _(function (push, next) {
+        push(null, 1);
+        push(e);
+        push(null, 2);
+        push(null, _.nil);
+    });
+    test.throws(function () {
+        s.done(function () {});
+    });
+    test.done();
+};
+
 exports['calls generator on read'] = function (test) {
     var gen_calls = 0;
     var s = _(function (push, next) {


### PR DESCRIPTION
A proposal for `.done()` as discussed in #54 and #55.

This modifies `.each` so that, instead of returning undefined, it returns a stream that ends after the return of the last call of the iterator.

Done is then derived from `toArray`, with the special `.ended` check for cases like:

    _([1,2,3]).each(function (x) {
        // do something
    }).done(function () {
        // do something else
    });

where `each` will have already ended due to its synchronous source.