### PR TITLE
Refactor: implement ncurry using partial.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -241,13 +241,8 @@ _.ncurry = function (n, fn /* args... */) {
     if (largs.length >= n) {
         return fn.apply(this, largs.slice(0, n));
     }
-    return function () {
-        var args = largs.concat(slice.call(arguments));
-        if (args.length < n) {
-            return _.ncurry.apply(this, [n, fn].concat(args));
-        }
-        return fn.apply(this, args.slice(0, n));
-    };
+
+    return _.partial.apply(this, [_.ncurry, n, fn].concat(largs));
 };
 
 /**


### PR DESCRIPTION
We are essentially doing partial application in the unsatisfied arguments path of `ncurry`. By relying on `partial` explicitly we reuse the library code and clean up the implementation a little.
