### PR TITLE
Throw an error if next or push is called after nil

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2003,14 +2003,20 @@ Stream.prototype.zipAll = function (ys) {
 
     var returned = 0;
     var z = [];
+    var finished = false;
 
     function nextValue(index, max, src, push, next) {
         src.pull(function (err, x) {
+            if (finished) {
+               return;
+            }
+
             if (err) {
                 push(err);
                 nextValue(index, max, src, push, next);
             }
             else if (x === _.nil) {
+                finished = true;
                 push(null, nil);
             }
             else {
@@ -2029,7 +2035,7 @@ Stream.prototype.zipAll = function (ys) {
         return _(function (push, next) {
             returned = 0;
             z = [];
-            for (var i = 0, length = array.length; i < length; i++) {
+            for (var i = 0, length = array.length; i < length && !finished; i++) {
                 nextValue(i, length, array[i], push, next);
             }
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -407,10 +407,22 @@ function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
     }
     else if (typeof xs === 'function') {
         this._generator = xs;
+        this._generator_nil_seen = false;
         this._generator_push = function (err, x) {
+            if (self._generator_nil_seen) {
+                throw new Error('Can not write to stream after nil');
+            }
+
+            if (x === _.nil) {
+                self._generator_nil_seen = true;
+            }
             self.write(err ? new StreamError(err) : x);
         };
         this._generator_next = function (s) {
+            if (self._generator_nil_seen) {
+                throw new Error('Can not call next after nil');
+            }
+
             if (s) {
                 // we MUST pause to get the redirect object into the _incoming
                 // buffer otherwise it would be passed directly to _send(),

--- a/test/test.js
+++ b/test/test.js
@@ -470,6 +470,34 @@ exports['async next from consumer'] = function (test) {
     });
 };
 
+exports['generator throws error if next called after nil'] = function(test) {
+    var s = _(function(push, next) {
+        push(null, 1);
+        push(null, _.nil);
+        next();
+    });
+
+    test.throws(function() {
+        s.resume();
+    });
+
+    test.done();
+};
+
+exports['generator throws error if push called after nil'] = function(test) {
+    var s = _(function(push, next) {
+        push(null, 1);
+        push(null, _.nil);
+        push(null, 2);
+    });
+
+    test.throws(function() {
+        s.resume();
+    });
+
+    test.done();
+};
+
 exports['errors'] = function (test) {
     var errs = [];
     var err1 = new Error('one');


### PR DESCRIPTION
This implements this comment: https://github.com/caolan/highland/issues/207#issuecomment-71706695

After `push(null _.nil)` is called for a generator, calling `push` or `next` throws an error.
Adding the test and implementation revealed another bug in `zipAll` that would try to write to the stream after nil has been pushed. That bug was fixed.