### PR TITLE
Throw an error if next or push is called after nil

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2011,6 +2011,7 @@ Stream.prototype.zipAll = function (ys) {
 
     var returned = 0;
     var z = [];
+    var finished = false;
 
     function nextValue(index, max, src, push, next) {
         src.pull(function (err, x) {
@@ -2019,7 +2020,10 @@ Stream.prototype.zipAll = function (ys) {
                 nextValue(index, max, src, push, next);
             }
             else if (x === _.nil) {
-                push(null, nil);
+                if (!finished) {
+                    finished = true;
+                    push(null, nil);
+                }
             }
             else {
                 returned++;

--- a/lib/index.js
+++ b/lib/index.js
@@ -368,6 +368,7 @@ function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
     this._observers = [];
     this._destructors = [];
     this._send_events = false;
+    this._nil_seen = false;
     this._delegate = null;
     this.source = null;
 
@@ -408,9 +409,21 @@ function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
     else if (typeof xs === 'function') {
         this._generator = xs;
         this._generator_push = function (err, x) {
+            if (self._nil_seen) {
+                throw new Error('Can not write to stream after nil');
+            }
+
+            if (x === nil) {
+                self._nil_seen = true;
+            }
+
             self.write(err ? new StreamError(err) : x);
         };
         this._generator_next = function (s) {
+            if (self._nil_seen) {
+                throw new Error('Can not call next after nil');
+            }
+
             if (s) {
                 // we MUST pause to get the redirect object into the _incoming
                 // buffer otherwise it would be passed directly to _send(),
@@ -974,8 +987,12 @@ Stream.prototype.consume = function (f) {
     var _send = s._send;
     var push = function (err, x) {
         //console.log(['push', err, x, s.paused]);
+        if (s._nil_seen) {
+            throw new Error('Can not write to stream after nil');
+        }
         if (x === nil) {
             // ended, remove consumer from source
+            s._nil_seen = true;
             self._removeConsumer(s);
         }
         if (s.paused) {
@@ -994,6 +1011,9 @@ Stream.prototype.consume = function (f) {
     var next_called;
     var next = function (s2) {
         //console.log(['next', async]);
+        if (s._nil_seen) {
+            throw new Error('Can not call next after nil');
+        }
         if (s2) {
             // we MUST pause to get the redirect object into the _incoming
             // buffer otherwise it would be passed directly to _send(),

--- a/test/test.js
+++ b/test/test.js
@@ -4319,7 +4319,9 @@ exports['latest'] = {
         var s2 = _.latest(s);
         var s3 = s2.consume(function (err, x, push, next) {
             push(err, x);
-            setTimeout(next, 60);
+            if (x !== _.nil) {
+                setTimeout(next, 60);
+            }
         });
         s3.toArray(function (xs) {
             // values at 0s, 60s, 120s
@@ -4349,14 +4351,16 @@ exports['latest'] = {
         var s2 = s.latest();
         var s3 = s2.consume(function (err, x, push, next) {
             push(err, x);
-            setTimeout(next, 60);
+            if (x !== _.nil) {
+                setTimeout(next, 60);
+            }
         });
         s3.toArray(function (xs) {
             // values at 0s, 60s, 120s
             test.same(xs, [1, 1, 'last']);
-            test.done();
         });
         this.clock.tick(1000);
+        test.done();
     },
     'let errors pass through': function (test) {
         test.expect(2);
@@ -4384,15 +4388,17 @@ exports['latest'] = {
         });
         var s3 = s2.consume(function (err, x, push, next) {
             push(err, x);
-            setTimeout(next, 60);
+            if (x !== _.nil) {
+                setTimeout(next, 60);
+            }
         });
         s3.toArray(function (xs) {
             // values at 0s, 60s, 120s
             test.same(xs, [1, 1, 'last']);
             test.same(errs, ['foo', 'bar']);
-            test.done();
         });
         this.clock.tick(1000);
+        test.done();
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -470,6 +470,76 @@ exports['async next from consumer'] = function (test) {
     });
 };
 
+exports['generator throws error if next called after nil'] = function (test) {
+    test.expect(1);
+    var nil_seen = false;
+    var s = _(function(push, next) {
+        // Ensure that next after nil is only called once
+        if (nil_seen) {
+            return;
+        }
+        push(null, 1);
+        nil_seen = true;
+        push(null, _.nil);
+        next();
+    });
+    test.throws(function() {
+        s.resume();
+    });
+    test.done();
+};
+
+exports['generator throws error if push called after nil'] = function (test) {
+    test.expect(1);
+    var s = _(function(push, next) {
+        push(null, 1);
+        push(null, _.nil);
+        push(null, 2);
+    });
+    test.throws(function() {
+        s.resume();
+    });
+    test.done();
+};
+
+exports['consume throws error if push called after nil'] = function (test) {
+    test.expect(1);
+    var s = _([1,2,3]);
+    var s2 = s.consume(function (err, x, push, next) {
+        push(null, x);
+        if (x === _.nil) {
+            push(null, 4);
+        } else {
+            next();
+        }
+    });
+    test.throws(function () {
+        s2.resume();
+    });
+    test.done();
+};
+
+exports['consume throws error if next called after nil'] = function (test) {
+    test.expect(1);
+    var s = _([1,2,3]);
+    var nil_seen = false;
+    var s2 = s.consume(function (err, x, push, next) {
+        // ensure we only call `next` after nil once
+        if (nil_seen) {
+            return;
+        }
+        if (x === _.nil) {
+            nil_seen = true;
+        }
+        push(null, x);
+        next();
+    });
+    test.throws(function () {
+        s2.resume();
+    });
+    test.done();
+};
+
 exports['errors'] = function (test) {
     var errs = [];
     var err1 = new Error('one');
@@ -4254,9 +4324,9 @@ exports['latest'] = {
         s3.toArray(function (xs) {
             // values at 0s, 60s, 120s
             test.same(xs, [1, 1, 'last']);
-            test.done();
         });
         this.clock.tick(1000);
+        test.done();
     },
     'GeneratorStream': function (test) {
         test.expect(1);


### PR DESCRIPTION
Supersedes https://github.com/caolan/highland/pull/218

This sets `_nil_seen` on the stream itself and then throws an error if `next` or `push` is called after nil has been seen.
This also includes fixes for zipAll as mentioned here: https://github.com/caolan/highland/pull/218#issuecomment-72394430
Finally, this includes the bug fixes to the test cases as discussed.