### PR TITLE
new invokeCallback method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3544,6 +3544,49 @@ _.wrapCallback = function (f) {
 };
 
 /**
+ * Like wrapCallback but used to wrap context dependent functions.
+ *
+ * @id invokeCallback
+ * @section Utils
+ * @name _.invokeCallback(context, method)
+ * @param {Object} context - the context in which to call the function
+ * @param {String} method - the method name to call
+ * @api public
+ *
+ * var fs = require('fs');
+ *
+ * var MyClass = function () {};
+ * MyClass.fileName = 'example.txt';
+ * MyClass.readFile = function (cb) {
+ *     fs.readFile(this.fileName, cb);
+ * };
+ *
+ * var readFile = _.invokeCallback(MyClass, 'readFile');
+ *
+ * readFile().apply(function (data) {
+ *     // data is now the contents of example.txt
+ * });
+ */
+
+_.invokeCallback = function (context, method) {
+    return function () {
+        var args = slice.call(arguments);
+        return _(function (push) {
+            var cb = function (err, x) {
+                if (err) {
+                    push(err);
+                }
+                else {
+                    push(null, x);
+                }
+                push(null, nil);
+            };
+            context[method].apply(context, args.concat([cb]));
+        });
+    };
+};
+
+/**
  * Add two values. Can be partially applied.
  *
  * @id add

--- a/test/test.js
+++ b/test/test.js
@@ -4729,6 +4729,21 @@ exports['wrapCallback - errors'] = function (test) {
     test.done();
 };
 
+exports['invokeCallback'] = function (test) {
+    var MyClass = function () {};
+    MyClass.val = 5;
+    MyClass.f = function (a, b, cb) {
+        var val = this.val;
+        setTimeout(function () {
+            cb(null, a + b + val);
+        }, 10);
+    };
+    _.invokeCallback(MyClass, 'f')(1, 2).toArray(function (xs) {
+        test.same(xs, [8]);
+        test.done();
+    });
+};
+
 exports['add'] = function (test) {
     test.equal(_.add(1, 2), 3);
     test.equal(_.add(3)(2), 5);


### PR DESCRIPTION
Includes new invokeCallback method and associated test.

This pull request is motivated by my personal difficulty in using highland with mongoose, the mongoDB odm.  Common mongoose async operations like Model.findOne({ _id: 'abc123' }, cb) are context dependent, and don't work with _.wrapCallback.

I've been extending highland with this method in my personal projects, but it's possible that I'm missing a simpler solution using highland's existing library.