### PR TITLE
Add transduce transform. Resolves #212.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2939,6 +2939,93 @@ Stream.prototype.scan1 = function (f) {
 };
 exposeMethod('scan1');
 
+var highlandTransform = {
+    init: function () {  },
+    result: function (push) {
+        // Don't push nil here. Otherwise, we can't catch errors from `result`
+        // and propagate them. The `transduce` implementation will do it.
+        return push;
+    },
+    step: function (push, input) {
+        push(null, input);
+        return push;
+    }
+};
+
+/**
+ * Applies the transformation defined by the the given *transducer* to the
+ * stream. A transducer is any function that follows the
+ * [Transducer Protocol](https://github.com/cognitect-labs/transducers-js#transformer-protocol).
+ *
+ * The `result` object that are passed in through the
+ * [Transformer Protocol](https://github.com/cognitect-labs/transducers-js#transformer-protocol)
+ * will be the `push` function provided by the [consume](#consume) transform.
+ *
+ * Like [scan](#scan), if the transducer throws an exception, the transform
+ * will stop and emit that error. Any intermediate values that were produced
+ * before the error will still be emitted.
+ *
+ * @id transduce
+ * @section Transforms
+ * @name Stream.transduce(xf)
+ * @param {Function} xf - The transducer.
+ * @api public
+ *
+ * _([1, 2, 3, 4]).transduce(require('transducer-js').map(_.add(1)))
+ * // => [2, 3, 4, 5]
+ */
+
+Stream.prototype.transduce = function transduce(xf) {
+    var transform = xf(highlandTransform);
+
+    return this.consume(function (err, x, push, next) {
+        if (err) {
+            // Pass through errors, like we always do.
+            push(err);
+            next();
+        }
+        else if (x === _.nil) {
+            runResult(push);
+        }
+        else {
+            var res = runStep(push, x);
+
+            if (!res) {
+                return;
+            }
+
+            if (res.__transducers_reduced__) {
+                runResult(res.value);
+            }
+            else {
+                next();
+            }
+        }
+    });
+
+    function runResult(push) {
+        try {
+            transform.result(push);
+        }
+        catch (e) {
+            push(e);
+        }
+        push(null, _.nil);
+    }
+
+    function runStep(push, x) {
+        try {
+            return transform.step(push, x);
+        }
+        catch (e) {
+            push(e);
+            push(null, _.nil);
+            return null;
+        }
+    }
+};
+exposeMethod('transduce');
+
 /**
  * Concatenates a Stream to the end of this Stream.
  *

--- a/lib/index.js
+++ b/lib/index.js
@@ -2956,6 +2956,8 @@ var highlandTransform = {
  * Applies the transformation defined by the the given *transducer* to the
  * stream. A transducer is any function that follows the
  * [Transducer Protocol](https://github.com/cognitect-labs/transducers-js#transformer-protocol).
+ * See [transduce-js](https://github.com/cognitect-labs/transducers-js) for
+ * more details on what transducers actually are.
  *
  * The `result` object that are passed in through the
  * [Transformer Protocol](https://github.com/cognitect-labs/transducers-js#transformer-protocol)

--- a/lib/index.js
+++ b/lib/index.js
@@ -2956,10 +2956,11 @@ var highlandTransform = {
  * Applies the transformation defined by the the given *transducer* to the
  * stream. A transducer is any function that follows the
  * [Transducer Protocol](https://github.com/cognitect-labs/transducers-js#transformer-protocol).
- * See [transduce-js](https://github.com/cognitect-labs/transducers-js) for
- * more details on what transducers actually are.
+ * See
+ * [transduce-js](https://github.com/cognitect-labs/transducers-js#transducers-js)
+ * for more details on what transducers actually are.
  *
- * The `result` object that are passed in through the
+ * The `result` object that is passed in through the
  * [Transformer Protocol](https://github.com/cognitect-labs/transducers-js#transformer-protocol)
  * will be the `push` function provided by the [consume](#consume) transform.
  *
@@ -2973,7 +2974,8 @@ var highlandTransform = {
  * @param {Function} xf - The transducer.
  * @api public
  *
- * _([1, 2, 3, 4]).transduce(require('transducer-js').map(_.add(1)))
+ * var xf = require('transducer-js').map(_.add(1));
+ * _([1, 2, 3, 4]).transduce(xf);
  * // => [2, 3, 4, 5]
  */
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "scrawl": "0.0.5",
     "sinon": "~1.8.2",
     "stream-array": "~1.0.1",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "transducers-js": "~0.4.135"
   },
   "scripts": {
     "test": "nodeunit test/test.js"

--- a/test/test.js
+++ b/test/test.js
@@ -2123,9 +2123,9 @@ exports['transduce'] = {
         this.xf = transducers.map(_.add(1));
         this.input = [1, 2, 3];
         this.expected = [2, 3, 4];
-        this.tester = function (test) {
+        this.tester = function (expected, test) {
             return function (xs) {
-                test.same(xs, self.expected);
+                test.same(xs, expected);
             };
         };
         cb();
@@ -2134,20 +2134,20 @@ exports['transduce'] = {
         test.expect(1);
         _(this.input)
             .transduce(this.xf)
-            .toArray(this.tester(test));
+            .toArray(this.tester(this.expected, test));
         test.done();
     },
     'GeneratorStream': function (test) {
         test.expect(1);
         generatorStream(this.input, 10)
             .transduce(this.xf)
-            .toArray(this.tester(test));
+            .toArray(this.tester(this.expected, test));
         setTimeout(test.done.bind(test), 10 * (this.input.length + 2));
     },
     'partial application': function (test) {
         test.expect(1);
         _.transduce(this.xf)(this.input)
-            .toArray(this.tester(test));
+            .toArray(this.tester(this.expected, test));
         test.done();
     },
     'passThroughError': function (test) {
@@ -2209,6 +2209,14 @@ exports['transduce'] = {
                 step: transform.step.bind(transform)
             };
         }
+    },
+    'early termination': function (test) {
+        test.expect(1);
+        var xf = transducers.take(1);
+        _([1, 2, 3])
+            .transduce(xf)
+            .toArray(this.tester([1], test));
+        test.done();
     },
     'noValueOnError': function (test) {
         noValueOnErrorTest(_.transduce(this.xf))(test);

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var EventEmitter = require('events').EventEmitter,
     streamify = require('stream-array'),
     concat = require('concat-stream'),
     Promise = require('es6-promise').Promise,
+    transducers = require('transducers-js'),
     _ = require('../lib/index');
 
 
@@ -53,6 +54,15 @@ function noValueOnErrorTest(transform, expected) {
             test.done();
         });
     }
+}
+
+function generatorStream(input, timeout) {
+    return _(function (push, next) {
+        for (var i = 0, len = input.length; i < len; i++) {
+            setTimeout(push.bind(null, null, input[i]), timeout * i);
+        }
+        setTimeout(push.bind(null, null, _.nil), timeout * len);
+    });
 }
 
 exports['ratelimit'] = {
@@ -2105,6 +2115,104 @@ exports['collect - GeneratorStream'] = function (test) {
         test.same(xs, [[1,2,3,4]]);
         test.done();
     });
+};
+
+exports['transduce'] = {
+    setUp: function (cb) {
+        var self = this;
+        this.xf = transducers.map(_.add(1));
+        this.input = [1, 2, 3];
+        this.expected = [2, 3, 4];
+        this.tester = function (test) {
+            return function (xs) {
+                test.same(xs, self.expected);
+            };
+        };
+        cb();
+    },
+    'ArrayStream': function (test) {
+        test.expect(1);
+        _(this.input)
+            .transduce(this.xf)
+            .toArray(this.tester(test));
+        test.done();
+    },
+    'GeneratorStream': function (test) {
+        test.expect(1);
+        generatorStream(this.input, 10)
+            .transduce(this.xf)
+            .toArray(this.tester(test));
+        setTimeout(test.done.bind(test), 10 * (this.input.length + 2));
+    },
+    'partial application': function (test) {
+        test.expect(1);
+        _.transduce(this.xf)(this.input)
+            .toArray(this.tester(test));
+        test.done();
+    },
+    'passThroughError': function (test) {
+        test.expect(4);
+        var s = _([1, 2, 3]).map(function (x) {
+            if (x === 2) {
+                throw new Error('error');
+            }
+            return x;
+        }).transduce(this.xf);
+
+        s.pull(valueEquals(test, 2));
+        s.pull(errorEquals(test, 'error'));
+        s.pull(valueEquals(test, 4));
+        s.pull(valueEquals(test, _.nil));
+        test.done();
+    },
+    'stopOnStepError': function (test) {
+        test.expect(3);
+        var s = _([1, 2, 3]).transduce(xf);
+
+        s.pull(valueEquals(test, 1));
+        s.pull(errorEquals(test, 'error'));
+        s.pull(valueEquals(test, _.nil));
+        test.done();
+
+        function xf(transform) {
+            return {
+                init: transform.init.bind(transform),
+                result: transform.result.bind(transform),
+                step: function (result, x) {
+                    if (x === 2) {
+                        throw new Error('error');
+                    }
+                    result = transform.step(result, x);
+                    return result;
+                }
+            };
+        }
+    },
+    'stopOnResultError': function (test) {
+        test.expect(5);
+        var s = _([1, 2, 3]).transduce(xf);
+
+        s.pull(valueEquals(test, 1));
+        s.pull(valueEquals(test, 2));
+        s.pull(valueEquals(test, 3));
+        s.pull(errorEquals(test, 'error'));
+        s.pull(valueEquals(test, _.nil));
+        test.done();
+
+        function xf(transform) {
+            return {
+                init: transform.init.bind(transform),
+                result: function (result) {
+                    transform.result(result);
+                    throw new Error('error');
+                },
+                step: transform.step.bind(transform)
+            };
+        }
+    },
+    'noValueOnError': function (test) {
+        noValueOnErrorTest(_.transduce(this.xf))(test);
+    },
 };
 
 exports['concat'] = function (test) {


### PR DESCRIPTION
Docs adapted from @kevinbeaty's suggestion, but with the parts about resuming streams stripped out, since no transform resumes streams.

Error handling:
- If `step` or `result` throws, then the transformation stops and the error (and `nil`) is pushed. This matches the behavior of `reduce` and `scan`.