### PR TITLE
Don't pause consumer if the consumer is async and the value is nil. Fixes #173.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1040,7 +1040,8 @@ Stream.prototype.consume = function (f) {
         next_called = false;
         f(err, x, push, next);
         async = true;
-        if (!next_called) {
+        // Don't pause if x is nil -- as next will never be called after
+        if (!next_called && x !== nil) {
             s.pause();
         }
     };

--- a/test/test.js
+++ b/test/test.js
@@ -288,6 +288,27 @@ exports['async consume'] = function (test) {
     });
 };
 
+
+exports['consume async nil'] = function (test) {
+    test.expect(1);
+    _([1])
+    .consume(function (err, x, push, next) {
+        if (x === _.nil) {
+            setTimeout(function() {
+              push(null, _.nil);
+            }, 10);
+        }
+        else {
+            push(null, x);
+            next();
+        }
+    })
+    .toArray(function (xs) {
+        test.same(xs, [1]);
+        test.done();
+    });
+};
+
 exports['passing Stream to constructor returns original'] = function (test) {
     var s = _([1,2,3]);
     test.strictEqual(s, _(s));

--- a/test/test.js
+++ b/test/test.js
@@ -288,15 +288,15 @@ exports['async consume'] = function (test) {
     });
 };
 
-
-exports['consume async nil'] = function (test) {
+exports['consume - push nil async (issue #173)'] = function (test) {
     test.expect(1);
-    _([1])
-    .consume(function (err, x, push, next) {
-        if (x === _.nil) {
-            setTimeout(function() {
-              push(null, _.nil);
-            }, 10);
+    _([1, 2, 3, 4]).consume(function(err, x, push, next) {
+        if (err !== null) {
+            push(err);
+            next();
+        }
+        else if (x === _.nil) {
+            _.setImmediate(push.bind(this, null, x));
         }
         else {
             push(null, x);
@@ -304,7 +304,7 @@ exports['consume async nil'] = function (test) {
         }
     })
     .toArray(function (xs) {
-        test.same(xs, [1]);
+        test.same(xs, [1, 2, 3, 4]);
         test.done();
     });
 };


### PR DESCRIPTION
If a consumer is going to push the nil asynchronously then it gets into a state where it is paused and will never call nil.
This changes a consumer so that it will not pause if it has already seen nil.