### PR TITLE
_.streamifyAll

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3544,6 +3544,114 @@ _.wrapCallback = function (f) {
 };
 
 /**
+ * Takes an object or a constructor function and returns that object or 
+ * constructor with streamified versions of its function properties.  
+ * Passed constructors will also have their prototype functions 
+ * streamified.  This is useful for wrapping many node style async 
+ * functions at once, and for preserving those functions' context.
+ *
+ * @id streamifyAll
+ * @section Utils
+ * @name _.streamifyAll(source)
+ * @param {Object | Function} source - the function or object with 
+ * node-style function properties.
+ * @api public
+ *
+ * var fs = _.streamifyAll(require('fs'));
+ *
+ * fs.readFileStream('example.txt').apply(function (data) {
+ *     // data is now the contents of example.txt
+ * });
+ */
+
+_.streamifyAll = function (arg) {
+    if (typeof arg !== 'function' && typeof arg !== 'object') {
+        throw new TypeError('takes an object or a constructor function');
+    }
+
+    // will not streamify inherited functions in ES3
+    var isES5 = (function () { 
+      "use strict";
+      return Function.prototype.bind && !this;
+    }());
+    var suffix = 'Stream';
+
+    var getKeys = function (obj) {
+        var keys = [];
+        for (var k in obj) {
+            if (hasOwn.call(obj, k)) {
+                keys.push(k);
+            }
+        }
+        return keys;
+    };
+
+    var isClass = function (fn) {
+        if (!(typeof fn === 'function' && fn.prototype)) { return false; }
+        var allKeys = isES5 ? Object.getOwnPropertyNames : getKeys;
+        var keys = allKeys(fn.prototype);
+        return keys.length > 0 && !(keys.length === 1 &&
+                keys[0] === "constructor");
+    };
+    
+    var getInheritedKeys = function (obj){
+        var allProps = {};
+        var curr = obj;
+        while(Object.getPrototypeOf(curr)) {
+            var props = Object.getOwnPropertyNames(curr)
+            props.forEach(function(prop){
+                if(typeof obj[prop] === 'function') {
+                    allProps[prop] = true;
+                }
+            });
+            curr = Object.getPrototypeOf(curr)
+        }
+        return getKeys(allProps)
+    };
+
+    var wrapWithContext = function (f) {
+        return function () {
+            var self = this;
+            var args = slice.call(arguments);
+            return _(function (push) {
+                var cb = function (err, x) {
+                    if (err) {
+                        push(err);
+                    }
+                    else {
+                        push(null, x);
+                    }
+                    push(null, nil);
+                };
+                f.apply(self, args.concat([cb]));
+            });
+        };
+    };
+
+    var streamifyAll = function (arg) {
+        var allKeys = isES5 ? getInheritedKeys : getKeys
+        var keys = allKeys(arg);
+        var rgx = new RegExp('^.*' + suffix + '$');
+
+        for (i = 0, len = keys.length; i < len; i++) {
+            var key = keys[i];
+            var val = arg[key];
+            if (typeof val === 'function' && !isClass(val)
+                && !key.match(rgx)) {
+                arg[key + suffix] = wrapWithContext(val);
+            }
+        }
+        return arg;
+    }
+
+    var ret = streamifyAll(arg);
+    if (isClass(arg)) { 
+        ret.prototype = streamifyAll(arg.prototype);
+    }
+    return ret;
+}
+
+/**
  * Add two values. Can be partially applied.
  *
  * @id add

--- a/lib/index.js
+++ b/lib/index.js
@@ -3639,16 +3639,16 @@ _.wrapCallback = function (f) {
 };
 
 /**
- * Takes an object or a constructor function and returns that object or 
- * constructor with streamified versions of its function properties.  
- * Passed constructors will also have their prototype functions 
- * streamified.  This is useful for wrapping many node style async 
+ * Takes an object or a constructor function and returns that object or
+ * constructor with streamified versions of its function properties.
+ * Passed constructors will also have their prototype functions
+ * streamified.  This is useful for wrapping many node style async
  * functions at once, and for preserving those functions' context.
  *
  * @id streamifyAll
  * @section Utils
  * @name _.streamifyAll(source)
- * @param {Object | Function} source - the function or object with 
+ * @param {Object | Function} source - the function or object with
  * node-style function properties.
  * @api public
  *
@@ -3665,8 +3665,8 @@ _.streamifyAll = function (arg) {
     }
 
     // will not streamify inherited functions in ES3
-    var isES5 = (function () { 
-      "use strict";
+    var isES5 = (function () {
+      'use strict';
       return Function.prototype.bind && !this;
     }());
     var suffix = 'Stream';
@@ -3686,24 +3686,25 @@ _.streamifyAll = function (arg) {
         var allKeys = isES5 ? Object.getOwnPropertyNames : getKeys;
         var keys = allKeys(fn.prototype);
         return keys.length > 0 && !(keys.length === 1 &&
-                keys[0] === "constructor");
+                keys[0] === 'constructor');
     };
-    
+
     var getInheritedKeys = function (obj){
         var allProps = {};
         var curr = obj;
-        while(Object.getPrototypeOf(curr)) {
-            var props = Object.getOwnPropertyNames(curr)
-            props.forEach(function(prop){
-                try {
-                    if(typeof obj[prop] === 'function') {
-                        allProps[prop] = true;
-                    }
-                } catch (e) {}
-            });
-            curr = Object.getPrototypeOf(curr)
+        var handleProp = function (prop) {
+            try {
+                if (typeof obj[prop] === 'function') {
+                    allProps[prop] = true;
+                }
+            } catch (e) {}
+        };
+        while (Object.getPrototypeOf(curr)) {
+            var props = Object.getOwnPropertyNames(curr);
+            props.forEach(handleProp);
+            curr = Object.getPrototypeOf(curr);
         }
-        return getKeys(allProps)
+        return getKeys(allProps);
     };
 
     var wrapWithContext = function (f) {
@@ -3725,28 +3726,28 @@ _.streamifyAll = function (arg) {
         };
     };
 
-    var streamifyAll = function (arg) {
-        var allKeys = isES5 ? getInheritedKeys : getKeys
-        var keys = allKeys(arg);
+    var streamifyAll = function (inp) {
+        var allKeys = isES5 ? getInheritedKeys : getKeys;
+        var keys = allKeys(inp);
         var rgx = new RegExp('^.*' + suffix + '$');
 
-        for (i = 0, len = keys.length; i < len; i++) {
+        for (var i = 0, len = keys.length; i < len; i++) {
             var key = keys[i];
-            var val = arg[key];
-            if (typeof val === 'function' && !isClass(val)
-                && !key.match(rgx)) {
-                arg[key + suffix] = wrapWithContext(val);
+            var val = inp[key];
+            if (typeof val === 'function' && !isClass(val) &&
+                !key.match(rgx)) {
+                inp[key + suffix] = wrapWithContext(val);
             }
         }
-        return arg;
-    }
+        return inp;
+    };
 
     var ret = streamifyAll(arg);
-    if (isClass(arg)) { 
+    if (isClass(arg)) {
         ret.prototype = streamifyAll(arg.prototype);
     }
     return ret;
-}
+};
 
 /**
  * Add two values. Can be partially applied.

--- a/lib/index.js
+++ b/lib/index.js
@@ -3600,9 +3600,11 @@ _.streamifyAll = function (arg) {
         while(Object.getPrototypeOf(curr)) {
             var props = Object.getOwnPropertyNames(curr)
             props.forEach(function(prop){
-                if(typeof obj[prop] === 'function') {
-                    allProps[prop] = true;
-                }
+                try {
+                    if(typeof obj[prop] === 'function') {
+                        allProps[prop] = true;
+                    }
+                } catch (e) {}
             });
             curr = Object.getPrototypeOf(curr)
         }

--- a/test/test.js
+++ b/test/test.js
@@ -4729,6 +4729,92 @@ exports['wrapCallback - errors'] = function (test) {
     test.done();
 };
 
+exports['streamifyAll'] = {
+    'throws when passed a non-function non-object': function (test) {
+        test.throws(function () {
+            _.streamifyAll(1);
+        }, TypeError);
+        test.done();
+    }, 
+    'streamifies object methods': function (test) { 
+        var plainObject = { fn: function (a, b, cb) { cb(null, a + b); } };
+        var obj = _.streamifyAll(plainObject);
+        test.equal(typeof obj.fnStream, 'function');
+        obj.fnStream(1, 2).apply(function (res) {
+            test.equal(res, 3);
+            test.done();
+        });
+    }, 
+    'streamifies constructor prototype methods': function (test) { 
+        function ExampleClass (a) { this.a = a; }
+        ExampleClass.prototype.fn = function (b, cb) {  cb(null, this.a + b); };
+        var ExampleClass = _.streamifyAll(ExampleClass);
+        obj = new ExampleClass(1);
+        test.equal(typeof obj.fnStream, 'function');
+        obj.fnStream(2).apply(function (res) {
+            test.equal(res, 3);
+            test.done();
+        });
+    }, 
+    'streamifies constructor methods': function (test) { 
+        function ExampleClass (a) { this.a = a; }
+        ExampleClass.a = 5;
+        ExampleClass.fn = function (b, cb) { cb(null, this.a + b); };
+        var ExampleClass = _.streamifyAll(ExampleClass);
+        test.equal(typeof ExampleClass.fnStream, 'function');
+        ExampleClass.fnStream(2).apply(function (res) {
+            test.equal(res, 7);
+            test.done();
+        });
+    }, 
+    'streamifies inherited methods': function (test) { 
+        function Grandfather () {}
+        Grandfather.prototype.fn1 = function (b, cb) { cb(null, this.a*b); }
+        function Father () {}
+        Father.prototype = Object.create(Grandfather.prototype);
+        Father.prototype.fn2 = function (b, cb) { cb(null, this.a/b); }
+        function Child (a) { this.a = a; }
+        Child.prototype = Object.create(Father.prototype);
+        Child.prototype.fn3 = function (b, cb) { cb(null, this.a+b); }
+        var Child = _.streamifyAll(Child);
+        var child = new Child(3);
+
+        test.equal(typeof child.fn1Stream, 'function');
+        test.equal(typeof child.fn2Stream, 'function');
+        test.equal(typeof child.fn3Stream, 'function');
+        _([child.fn1Stream(1), child.fn2Stream(2), child.fn3Stream(3)])
+            .series()
+            .toArray(function (arr) {
+                test.deepEqual(arr, [3, 1.5, 6]);
+                test.done();
+            });
+    }, 
+    'does not re-streamify functions': function (test) { 
+        var plainObject = { fn: function (a, b, cb) { cb(null, a + b); } };
+        var obj = _.streamifyAll(_.streamifyAll(plainObject));
+        test.equal(typeof obj.fnStreamStream, 'undefined');
+        test.done();
+    }, 
+    'does not streamify constructors': function (test) { 
+        function ExampleClass () {}
+        ExampleClass.prototype.fn = function (cb) { cb(null, 'foo'); }
+        var obj = new (_.streamifyAll(ExampleClass))();
+        test.equal(typeof obj.constructorStream, 'undefined');
+        test.done();
+    }, 
+    'does not streamify Object methods': function (test) { 
+        function ExampleClass () {}
+        ExampleClass.prototype.fn = function (cb) { cb(null, 'foo'); }
+        var obj1 = new (_.streamifyAll(ExampleClass))();
+        var obj2 = _.streamifyAll(new ExampleClass());
+        test.equal(typeof obj1.toStringStream, 'undefined');
+        test.equal(typeof obj1.keysStream, 'undefined');
+        test.equal(typeof obj2.toStringStream, 'undefined');
+        test.equal(typeof obj2.keysStream, 'undefined');
+        test.done();
+    },
+};
+
 exports['add'] = function (test) {
     test.equal(_.add(1, 2), 3);
     test.equal(_.add(3)(2), 5);

--- a/test/test.js
+++ b/test/test.js
@@ -4813,6 +4813,16 @@ exports['streamifyAll'] = {
         test.equal(typeof obj2.keysStream, 'undefined');
         test.done();
     },
+    "doesn't break when property has custom getter": function (test) {
+        function ExampleClass (a) { this.a = { b: a }; }
+        Object.defineProperty(ExampleClass.prototype, 'c',
+            { get: function () { return this.a.b; } });
+        
+        test.doesNotThrow(function () {
+            _.streamifyAll(ExampleClass);    
+        });
+        test.done();
+    }
 };
 
 exports['add'] = function (test) {


### PR DESCRIPTION
At the suggestion of @LewisJEllis I've written a preliminary streamifyAll implementation, the highland equivalent of bluebird's promisifyAll.

On top of the included unit tests I did some manual integration tests with mongoose and I didn't run into any problems.

It might be worth adding options for custom filters, streamifiers, and suffixes as offered in bluebird.

Thanks