### PR TITLE
Ensure _.through Propogates Node Stream Errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2424,7 +2424,7 @@ exposeMethod('last');
  * Passes the current Stream to a function, returning the result. Can also
  * be used to pipe the current Stream through another Stream. It will always
  * return a Highland Stream (instead of the piped to target directly as in
- * Node.js).
+ * Node.js). Any errors emitted will be propagated as Highland errors.
  *
  * @id through
  * @section Higher-order Streams
@@ -2448,17 +2448,29 @@ exposeMethod('last');
  * _(filenames).through(jsonParser).map(function (obj) {
  *     // ...
  * });
+ *
+ * // All errors will be propagated as Highland errors
+ * _(['zz{"a": 1}']).through(jsonParser).errors(function (err) {
+ *   console.log(err); // => SyntaxError: Unexpected token z
+ * });
  */
 
 Stream.prototype.through = function (target) {
+    var output;
+
     if (_.isFunction(target)) {
         return target(this);
     }
     else {
-        var output = _();
         target.pause();
-        this.pipe(target).pipe(output);
-        return output;
+        output = _();
+        this.on('error', writeErr);
+        target.on('error', writeErr);
+        return this.pipe(target).pipe(output);
+    }
+
+    function writeErr(err) {
+        output.write(new StreamError(err));
     }
 };
 exposeMethod('through');


### PR DESCRIPTION
I've recently been using Dominic Tarr's JSONStream and found it very puzzling why errors in `_.through` were not being caught by my `errors` function:

```javascript
_(req).through(JSONStream.parse()).errors(handleInvalidJsonError)
```
The reason I used `through` was because I wanted to 'Highlandify' the only non-Highland stream in my chain and I suspect that's what many others would think too. After a bit of digging around in the code and the issues I found that there's a fix for this planned but it's part of the wider refactorings planned for 3.0 (#191). I'm just adding a note to the documentation to warn people about this behaviour in case they get tripped up by it like I did. There's a fairly simple work around, which is to wrap the whole `pipe` expression in another Highland stream:

```javascript
_(_(req).pipe(JSONStream.parse())).errors(handleInvalidJsonError)
```
But it strikes me, would it not be an acceptable interim fix to just do this in the `through` method rather than wait until 3.0 drops?

```javascript
Stream.prototype.through = function (target) {
    if (_.isFunction(target)) {
        return target(this);
    }
    else {
        var output = _();
        target.pause();
        _(this.pipe(target)).pipe(output);
        return output;
    }
};
```
Or is there something I'm not considering?