### PR TITLE
streamifyAll implementation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3745,6 +3745,118 @@ _.wrapCallback = function (f) {
 };
 
 /**
+ * Takes an object or a constructor function and returns that object or
+ * constructor with streamified versions of its function properties.
+ * Passed constructors will also have their prototype functions
+ * streamified.  This is useful for wrapping many node style async
+ * functions at once, and for preserving those functions' context.
+ *
+ * @id streamifyAll
+ * @section Utils
+ * @name _.streamifyAll(source)
+ * @param {Object | Function} source - the function or object with
+ * node-style function properties.
+ * @api public
+ *
+ * var fs = _.streamifyAll(require('fs'));
+ *
+ * fs.readFileStream('example.txt').apply(function (data) {
+ *     // data is now the contents of example.txt
+ * });
+ */
+
+
+var isES5 = (function () {
+  'use strict';
+  return Function.prototype.bind && !this;
+}());
+
+function keys (obj) {
+    var keys = [];
+    for (var k in obj) {
+        if (hasOwn.call(obj, k)) {
+            keys.push(k);
+        }
+    }
+    return keys;
+}
+
+function isClass (fn) {
+    if (!(typeof fn === 'function' && fn.prototype)) { return false; }
+    var getKeys = isES5 ? Object.getOwnPropertyNames : keys;
+    var allKeys = getKeys(fn.prototype);
+    return allKeys.length > 0 && !(allKeys.length === 1 &&
+            allKeys[0] === 'constructor');
+}
+
+function inheritedKeys (obj) {
+    var allProps = {};
+    var curr = obj;
+    var handleProp = function (prop) {
+        allProps[prop] = true;
+    };
+    while (Object.getPrototypeOf(curr)) {
+        var props = Object.getOwnPropertyNames(curr);
+        props.forEach(handleProp);
+        curr = Object.getPrototypeOf(curr);
+    }
+    return keys(allProps);
+}
+
+function wrapWithContext (f) {
+    return function () {
+        var self = this;
+        var args = slice.call(arguments);
+        return _(function (push) {
+            var cb = function (err, x) {
+                if (err) {
+                    push(err);
+                }
+                else {
+                    push(null, x);
+                }
+                push(null, nil);
+            };
+            f.apply(self, args.concat([cb]));
+        });
+    };
+}
+
+function streamifyAll (inp, suffix) {
+    // will not streamify inherited functions in ES3
+    var getKeys = isES5 ? inheritedKeys : keys;
+    var allKeys = getKeys(inp);
+
+    for (var i = 0, len = allKeys.length; i < len; i++) {
+        var key = allKeys[i];
+        var val;
+        // will skip context aware getters
+        try { val = inp[key]; } catch (e) {}
+        if (val && typeof val === 'function' && !isClass(val) &&
+                !val.__HighlandStreamifiedFunction__) {
+
+            var streamified = wrapWithContext(val);
+            streamified.__HighlandStreamifiedFunction__ = true;
+            inp[key + suffix] = streamified;
+        }
+    }
+    return inp;
+}
+
+_.streamifyAll = function (arg) {
+    if (typeof arg !== 'function' && typeof arg !== 'object') {
+        throw new TypeError('takes an object or a constructor function');
+    }
+    var suffix = 'Stream';
+
+    var ret = streamifyAll(arg, suffix);
+    if (isClass(arg)) {
+        ret.prototype = streamifyAll(arg.prototype, suffix);
+    }
+    return ret;
+};
+
+/**
  * Add two values. Can be partially applied.
  *
  * @id add

--- a/test/test.js
+++ b/test/test.js
@@ -5019,6 +5019,102 @@ exports['wrapCallback - errors'] = function (test) {
     test.done();
 };
 
+exports['streamifyAll'] = {
+    'throws when passed a non-function non-object': function (test) {
+        test.throws(function () {
+            _.streamifyAll(1);
+        }, TypeError);
+        test.done();
+    },
+    'streamifies object methods': function (test) {
+        var plainObject = { fn: function (a, b, cb) { cb(null, a + b); } };
+        var obj = _.streamifyAll(plainObject);
+        test.equal(typeof obj.fnStream, 'function');
+        obj.fnStream(1, 2).apply(function (res) {
+            test.equal(res, 3);
+            test.done();
+        });
+    },
+    'streamifies constructor prototype methods': function (test) {
+        function ExampleClass (a) { this.a = a; }
+        ExampleClass.prototype.fn = function (b, cb) {  cb(null, this.a + b); };
+        var ExampleClass = _.streamifyAll(ExampleClass);
+        var obj = new ExampleClass(1);
+        test.equal(typeof obj.fnStream, 'function');
+        obj.fnStream(2).apply(function (res) {
+            test.equal(res, 3);
+            test.done();
+        });
+    },
+    'streamifies constructor methods': function (test) {
+        function ExampleClass (a) { this.a = a; }
+        ExampleClass.a = 5;
+        ExampleClass.fn = function (b, cb) { cb(null, this.a + b); };
+        var ExampleClass = _.streamifyAll(ExampleClass);
+        test.equal(typeof ExampleClass.fnStream, 'function');
+        ExampleClass.fnStream(2).apply(function (res) {
+            test.equal(res, 7);
+            test.done();
+        });
+    },
+    'streamifies inherited methods': function (test) {
+        function Grandfather () {}
+        Grandfather.prototype.fn1 = function (b, cb) { cb(null, this.a*b); };
+        function Father () {}
+        Father.prototype = Object.create(Grandfather.prototype);
+        Father.prototype.fn2 = function (b, cb) { cb(null, this.a/b); };
+        function Child (a) { this.a = a; }
+        Child.prototype = Object.create(Father.prototype);
+        Child.prototype.fn3 = function (b, cb) { cb(null, this.a+b); };
+        var Child = _.streamifyAll(Child);
+        var child = new Child(3);
+
+        test.equal(typeof child.fn1Stream, 'function');
+        test.equal(typeof child.fn2Stream, 'function');
+        test.equal(typeof child.fn3Stream, 'function');
+        _([child.fn1Stream(1), child.fn2Stream(2), child.fn3Stream(3)])
+            .series()
+            .toArray(function (arr) {
+                test.deepEqual(arr, [3, 1.5, 6]);
+                test.done();
+            });
+    },
+    'does not re-streamify functions': function (test) {
+        var plainObject = { fn: function (a, b, cb) { cb(null, a + b); } };
+        var obj = _.streamifyAll(_.streamifyAll(plainObject));
+        test.equal(typeof obj.fnStreamStream, 'undefined');
+        test.done();
+    },
+    'does not streamify constructors': function (test) {
+        function ExampleClass () {}
+        ExampleClass.prototype.fn = function (cb) { cb(null, 'foo'); };
+        var obj = new (_.streamifyAll(ExampleClass))();
+        test.equal(typeof obj.constructorStream, 'undefined');
+        test.done();
+    },
+    'does not streamify Object methods': function (test) {
+        function ExampleClass () {}
+        ExampleClass.prototype.fn = function (cb) { cb(null, 'foo'); };
+        var obj1 = new (_.streamifyAll(ExampleClass))();
+        var obj2 = _.streamifyAll(new ExampleClass());
+        test.equal(typeof obj1.toStringStream, 'undefined');
+        test.equal(typeof obj1.keysStream, 'undefined');
+        test.equal(typeof obj2.toStringStream, 'undefined');
+        test.equal(typeof obj2.keysStream, 'undefined');
+        test.done();
+    },
+    "doesn't break when property has custom getter": function (test) {
+        function ExampleClass (a) { this.a = { b: a }; }
+        Object.defineProperty(ExampleClass.prototype, 'c',
+            { get: function () { return this.a.b; } });
+
+        test.doesNotThrow(function () {
+            _.streamifyAll(ExampleClass);
+        });
+        test.done();
+    }
+};
+
 exports['add'] = function (test) {
     test.equal(_.add(1, 2), 3);
     test.equal(_.add(3)(2), 5);


### PR DESCRIPTION
- highland equivalent of bluebird's promisifyAll

original pull request
https://github.com/caolan/highland/pull/226/files#r24818506

I created a new fork in order to clean up the commit history.  

At @vqvu 's suggestion I pulled streamifyAll's helper functions into the global scope and refactored so that it uses a flag to identify streamified functions rather than a regex matcher.

Vqvu also suggested that I pull streamifyAll into a separate file. While I do agree this would improve readability, it would also require a larger refactor which ideally would involve the design input of other contributors.