### PR TITLE
Implement mappingHint for wrapCallback, fixes #246

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -415,6 +415,34 @@ function iteratorGenerator(it) {
     });
 }
 
+function hintMapper(mappingHint) {
+    var mappingHintType = (typeof mappingHint);
+    var mapper;
+
+    if (mappingHintType === 'function') {
+        mapper = mappingHint;
+    }
+    else if (mappingHintType === 'number') {
+        mapper = function () {
+            return slice.call(arguments, 0, mappingHint);
+        };
+    }
+    else if (_.isArray(mappingHint)) {
+        mapper = function () {
+            var args = arguments;
+            return mappingHint.reduce(function (ctx, hint, idx) {
+                ctx[hint] = args[idx];
+                return ctx;
+            }, {});
+        };
+    }
+    else {
+        mapper = function (x) { return x; };
+    }
+
+    return mapper;
+}
+
 /**
  * Actual Stream constructor wrapped the the main exported function
  */
@@ -553,29 +581,7 @@ function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
         }
     }
     else if (_.isString(xs)) {
-        var mappingHintType = (typeof mappingHint);
-        var mapper;
-
-        if (mappingHintType === 'function') {
-            mapper = mappingHint;
-        }
-        else if (mappingHintType === 'number') {
-            mapper = function () {
-                return slice.call(arguments, 0, mappingHint);
-            };
-        }
-        else if (_.isArray(mappingHint)) {
-            mapper = function () {
-                var args = arguments;
-                return mappingHint.reduce(function (ctx, hint, idx) {
-                    ctx[hint] = args[idx];
-                    return ctx;
-                }, {});
-            };
-        }
-        else {
-            mapper = function (x) { return x; };
-        }
+        var mapper = hintMapper(mappingHint);
 
         ee.on(xs, function () {
             var ctx = mapper.apply(this, arguments);
@@ -4012,17 +4018,21 @@ _.log = function () {
  * Reader.prototype.readStream = _.wrapCallback(Reader.prototype.read);
  */
 
-_.wrapCallback = function (f) {
+_.wrapCallback = function (f, /*optional*/mappingHint) {
+    var mapper = hintMapper(mappingHint);
+
     return function () {
         var self = this;
         var args = slice.call(arguments);
         return _(function (push) {
-            var cb = function (err, x) {
+            var cb = function (err) {
                 if (err) {
                     push(err);
                 }
                 else {
-                    push(null, x);
+                    var args = slice.call(arguments, 1);
+                    var v = mapper.apply(this, args);
+                    push(null, v);
                 }
                 push(null, nil);
             };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3988,8 +3988,15 @@ _.log = function () {
 /**
  * Wraps a node-style async function which accepts a callback, transforming
  * it to a function which accepts the same arguments minus the callback and
- * returns a Highland Stream instead. Only the first argument to the
- * callback (or an error) will be pushed onto the Stream. The wrapped
+ * returns a Highland Stream instead.
+
+ * If no mapping hint is provided, only the first argument to the callback
+ * (or an error) will be pushed onto the Stream. If mappingHint is a number,
+ * an array of that length will be pushed onto the stream, containing
+ * exactly that many parameters from the callback. If it's an array, it's
+ * used as keys to map the arguments into an object which is pushed to the
+ * Stream. If the mapping hint is a function, it's called with the (non-error)
+ * arguments to the callback, and the returned value is pushed. The wrapped
  * function keeps its context, so you can safely use it as a method without
  * binding (see the second example below).
  *
@@ -3997,6 +4004,7 @@ _.log = function () {
  * @section Utils
  * @name _.wrapCallback(f)
  * @param {Function} f - the node-style function to wrap
+ * @param {Function | Number | Array} mappingHint - how to pass the arguments to the callback (optional)
  * @api public
  *
  * var fs = require('fs');

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,9 +42,14 @@ var Decoder = require('string_decoder').StringDecoder;
  * event emitter as the two arguments to the constructor and the first
  * argument emitted to the event handler will be written to the new Stream.
  *
- * You can also pass as an optional third parameter a function, an array of strings
- * or a number. In this case the event handler will try to wrap the arguments emitted
- * to it and write this object to the new stream.
+ * You can pass a mapping hint as the third argument, which specifies how
+ * event arguments are passed into the stream. If no mapping hint is provided,
+ * only the first value emitted with the event to the will be pushed onto the
+ * Stream. If mappingHint is a number, an array of that length will be pushed
+ * onto the stream, containing exactly that many parameters from the event. If
+ * it's an array, it's used as keys to map the arguments into an object which
+ * is pushed to the tream. If the mapping hint is a function, it's called with
+ * the event arguments, and the returned value is pushed.
  *
  * **Promise -** Accepts an ES6 / jQuery style promise and returns a
  * Highland Stream which will emit a single value (or an error).
@@ -3988,17 +3993,14 @@ _.log = function () {
 /**
  * Wraps a node-style async function which accepts a callback, transforming
  * it to a function which accepts the same arguments minus the callback and
- * returns a Highland Stream instead.
-
- * If no mapping hint is provided, only the first argument to the callback
- * (or an error) will be pushed onto the Stream. If mappingHint is a number,
- * an array of that length will be pushed onto the stream, containing
- * exactly that many parameters from the callback. If it's an array, it's
- * used as keys to map the arguments into an object which is pushed to the
- * Stream. If the mapping hint is a function, it's called with the (non-error)
- * arguments to the callback, and the returned value is pushed. The wrapped
- * function keeps its context, so you can safely use it as a method without
- * binding (see the second example below).
+ * returns a Highland Stream instead. The wrapped function keeps its context,
+ * so you can safely use it as a method without binding (see the second
+ * example below).
+ *
+ * wrapCallback also accepts a mapping hint, which specifies how callback
+ * arguments are pushed to the stream. This can be a function, number, or
+ * array. See the documentation on [EventEmitter Stream Objects](#Stream Objects)
+ * for details.
  *
  * @id wrapCallback
  * @section Utils
@@ -4026,7 +4028,9 @@ _.log = function () {
  * Reader.prototype.readStream = _.wrapCallback(Reader.prototype.read);
  */
 
+/*eslint-disable no-multi-spaces */
 _.wrapCallback = function (f, /*optional*/mappingHint) {
+    /*eslint-enable no-multi-spaces */
     var mapper = hintMapper(mappingHint);
 
     return function () {
@@ -4038,8 +4042,8 @@ _.wrapCallback = function (f, /*optional*/mappingHint) {
                     push(err);
                 }
                 else {
-                    var args = slice.call(arguments, 1);
-                    var v = mapper.apply(this, args);
+                    var cbArgs = slice.call(arguments, 1);
+                    var v = mapper.apply(this, cbArgs);
                     push(null, v);
                 }
                 push(null, nil);

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,9 +43,13 @@ var Decoder = require('string_decoder').StringDecoder;
  * argument emitted to the event handler will be written to the new Stream.
  *
  * You can pass a mapping hint as the third argument, which specifies how
- * event arguments are passed into the stream. If no mapping hint is provided,
+ * event arguments are pushed into the stream. If no mapping hint is provided,
  * only the first value emitted with the event to the will be pushed onto the
- * Stream. If mappingHint is a number, an array of that length will be pushed
+ * Stream. (NB: in a future version, if more than one argument is passed to the
+ * event, an array of all arguments will be pushed to the stream; currently the
+ * extra arguments are dropped)
+ *
+ * If mappingHint is a number, an array of that length will be pushed
  * onto the stream, containing exactly that many parameters from the event. If
  * it's an array, it's used as keys to map the arguments into an object which
  * is pushed to the tream. If the mapping hint is a function, it's called with

--- a/test/test.js
+++ b/test/test.js
@@ -5755,6 +5755,39 @@ exports['wrapCallback - errors'] = function (test) {
     test.done();
 };
 
+exports['wrapCallback with args wrapping by function'] = function (test) {
+    function f(cb) {
+        cb(null, 1, 2, 3);
+    }
+    function mapper(){
+        return Array.prototype.slice.call(arguments);
+    }
+    _.wrapCallback(f, mapper)().each(function (x) {
+        test.same(x, [1, 2, 3]);
+        test.done();
+    });
+};
+
+exports['wrapCallback with args wrapping by number'] = function (test) {
+    function f(cb) {
+        cb(null, 1, 2, 3);
+    }
+    _.wrapCallback(f, 2)().each(function (x) {
+        test.same(x, [1, 2]);
+        test.done();
+    });
+};
+
+exports['wrapCallback with args wrapping by array'] = function (test) {
+    function f(cb) {
+        cb(null, 1, 2, 3);
+    }
+    _.wrapCallback(f, ['one', 'two', 'three'])().each(function (x) {
+        test.same(x, {'one': 1, 'two': 2, 'three': 3});
+        test.done()
+    });
+};
+
 exports['streamifyAll'] = {
     'throws when passed a non-function non-object': function (test) {
         test.throws(function () {

--- a/test/test.js
+++ b/test/test.js
@@ -1744,6 +1744,19 @@ exports['wrap EventEmitter (or jQuery) on handler with args wrapping by array'] 
     });
 };
 
+exports['wrap EventEmitter default mapper discards all but first arg'] = function (test) {
+    var ee = {
+        on: function (name, f) {
+            test.same(name, 'myevent');
+            f(1, 2, 3);
+        }
+    };
+    _('myevent', ee).each(function (x) {
+        test.same(x, 1);
+        test.done()
+    });
+};
+
 exports['sequence'] = function (test) {
     _.sequence([[1,2], [3], [[4],5]]).toArray(function (xs) {
         test.same(xs, [1,2,3,[4],5]);
@@ -5784,6 +5797,16 @@ exports['wrapCallback with args wrapping by array'] = function (test) {
     }
     _.wrapCallback(f, ['one', 'two', 'three'])().each(function (x) {
         test.same(x, {'one': 1, 'two': 2, 'three': 3});
+        test.done()
+    });
+};
+
+exports['wrapCallback default mapper discards all but first arg'] = function (test) {
+    function f(cb) {
+        cb(null, 1, 2, 3);
+    }
+    _.wrapCallback(f)().each(function (x) {
+        test.same(x, 1);
         test.done()
     });
 };


### PR DESCRIPTION
I definitely think this is a useful thing to have (seems like an omission that it was only for EventEmitters and not `wrapCallback` too). Can someone check if the docs make sense to someone who isn't sleep-deprived?