### PR TITLE
Keep context in wrapCallback (and use wrapCallback in streamifyAll)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3776,6 +3776,7 @@ _.log = function () {
 
 _.wrapCallback = function (f) {
     return function () {
+        var self = this;
         var args = slice.call(arguments);
         return _(function (push) {
             var cb = function (err, x) {
@@ -3787,7 +3788,7 @@ _.wrapCallback = function (f) {
                 }
                 push(null, nil);
             };
-            f.apply(null, args.concat([cb]));
+            f.apply(self, args.concat([cb]));
         });
     };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3757,7 +3757,9 @@ _.log = function () {
  * Wraps a node-style async function which accepts a callback, transforming
  * it to a function which accepts the same arguments minus the callback and
  * returns a Highland Stream instead. Only the first argument to the
- * callback (or an error) will be pushed onto the Stream.
+ * callback (or an error) will be pushed onto the Stream. The wrapped
+ * function keeps its context, so you can safely use it as a method without
+ * binding (see the second example below).
  *
  * @id wrapCallback
  * @section Utils
@@ -3772,6 +3774,16 @@ _.log = function () {
  * readFile('example.txt').apply(function (data) {
  *     // data is now the contents of example.txt
  * });
+ * 
+ * function Reader(file) {
+ *     this.file = file;
+ * }
+ * 
+ * Reader.prototype.read = function(cb) {
+ *     fs.readFile(this.file, cb);
+ * };
+ * 
+ * Reader.prototype.readStream = _.wrapCallback(Reader.prototype.read);
  */
 
 _.wrapCallback = function (f) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3852,25 +3852,6 @@ function inheritedKeys (obj) {
     return keys(allProps);
 }
 
-function wrapWithContext (f) {
-    return function () {
-        var self = this;
-        var args = slice.call(arguments);
-        return _(function (push) {
-            var cb = function (err, x) {
-                if (err) {
-                    push(err);
-                }
-                else {
-                    push(null, x);
-                }
-                push(null, nil);
-            };
-            f.apply(self, args.concat([cb]));
-        });
-    };
-}
-
 function streamifyAll (inp, suffix) {
     // will not streamify inherited functions in ES3
     var getKeys = isES5 ? inheritedKeys : keys;
@@ -3884,7 +3865,7 @@ function streamifyAll (inp, suffix) {
         if (val && typeof val === 'function' && !isClass(val) &&
                 !val.__HighlandStreamifiedFunction__) {
 
-            var streamified = wrapWithContext(val);
+            var streamified = _.wrapCallback(val);
             streamified.__HighlandStreamifiedFunction__ = true;
             inp[key + suffix] = streamified;
         }

--- a/test/test.js
+++ b/test/test.js
@@ -5062,6 +5062,22 @@ exports['wrapCallback'] = function (test) {
     });
 };
 
+exports['wrapCallback - context'] = function (test) {
+    var o = {
+        f: function (a, b, cb) {
+            test.equal(this, o);
+            setTimeout(function () {
+                cb(null, a + b);
+            }, 10);
+        }
+    };
+    o.g = _.wrapCallback(o.f);
+    o.g(1, 2).toArray(function (xs) {
+        test.same(xs, [3]);
+        test.done();
+    });
+};
+
 exports['wrapCallback - errors'] = function (test) {
     var f = function (a, b, cb) {
         cb(new Error('boom'));


### PR DESCRIPTION
As discussed in #247