### PR TITLE
Update to latest transformer protocol & use init (Resolves #260).

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3150,17 +3150,23 @@ Stream.prototype.scan1 = function (f) {
 };
 exposeMethod('scan1');
 
-var highlandTransform = {
-    init: function () {  },
-    result: function (push) {
-        // Don't push nil here. Otherwise, we can't catch errors from `result`
-        // and propagate them. The `transduce` implementation will do it.
-        return push;
-    },
-    step: function (push, input) {
-        push(null, input);
-        return push;
-    }
+function HighlandTransform(push) {
+    this.push = push;
+}
+
+HighlandTransform.prototype['@@transducer/init'] = function () {
+    return this.push;
+};
+
+HighlandTransform.prototype['@@transducer/result'] = function (push) {
+    // Don't push nil here. Otherwise, we can't catch errors from `result`
+    // and propagate them. The `transduce` implementation will do it.
+    return push;
+};
+
+HighlandTransform.prototype['@@transducer/step'] = function (push, input) {
+    push(null, input);
+    return push;
 };
 
 /**
@@ -3191,26 +3197,35 @@ var highlandTransform = {
  */
 
 Stream.prototype.transduce = function transduce(xf) {
-    var transform = xf(highlandTransform);
+    var transform = null,
+        memo = null;
 
     return this.consume(function (err, x, push, next) {
+        if (transform == null) {
+            transform = xf(new HighlandTransform(push));
+            memo = transform['@@transducer/init']();
+        }
+
         if (err) {
             // Pass through errors, like we always do.
             push(err);
             next();
         }
         else if (x === _.nil) {
-            runResult(push);
+            // Push may be different from memo depending on the transducer that
+            // we get.
+            runResult(push, memo);
         }
         else {
-            var res = runStep(push, x);
+            var res = runStep(push, memo, x);
 
             if (!res) {
                 return;
             }
 
-            if (res.__transducers_reduced__) {
-                runResult(res.value);
+            memo = res;
+            if (memo['@@transducer/reduced']) {
+                runResult(memo['@@transducer/value']);
             }
             else {
                 next();
@@ -3218,9 +3233,9 @@ Stream.prototype.transduce = function transduce(xf) {
         }
     });
 
-    function runResult(push) {
+    function runResult(push, memo) {
         try {
-            transform.result(push);
+            transform['@@transducer/result'](memo);
         }
         catch (e) {
             push(e);
@@ -3228,9 +3243,9 @@ Stream.prototype.transduce = function transduce(xf) {
         push(null, _.nil);
     }
 
-    function runStep(push, x) {
+    function runStep(push, memo, x) {
         try {
-            return transform.step(push, x);
+            return transform['@@transducer/step'](memo, x);
         }
         catch (e) {
             push(e);


### PR DESCRIPTION
Updates to the latest version of the [transformer protocol](https://github.com/cognitect-labs/transducers-js#transformer-protocol).

This also changes the implementation to actually use the `@@transducer/init` method, which will allow users to use transformers that wrap the `result` object for their own purposes.