### PR TITLE
Use cdn.rawgit.com instead of rawgithub.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="css/highland.css">
     <link rel="stylesheet" href="css/highlight.github.css">
     <script src="js/vendor/modernizr.js"></script>
-    <script src="https://rawgithub.com/caolan/highland/master/dist/highland.js" type="text/javascript"></script>
+    <script src="https://cdn.rawgit.com/caolan/highland/2.4.0/dist/highland.js" type="text/javascript"></script>
 
   </head>
   <body>


### PR DESCRIPTION
I'm seeing this currently on the site:

![screen shot 2015-04-16 at 11 32 43 am](https://cloud.githubusercontent.com/assets/542108/7188491/14c92cf8-e42d-11e4-9b30-e2787f5239a2.png)

I also switched it from master to the latest tag because according to [rawgit.com](https://rawgit.com/):
> It's best to use a specific tag or commit hash in the URL (not a branch). Files are cached permanently after the first request.