### PR TITLE
Add zipAll that works on stream of streams. (Resolves #263).

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2206,7 +2206,7 @@ Stream.prototype.zipAll0 = function () {
         });
     }
 
-    return this.map(_).collect().flatMap(function (array) {
+    return this.collect().flatMap(function (array) {
         if (!array.length) {
             return _([]);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2225,10 +2225,7 @@ exposeMethod('zipAll0');
 
 /**
  * Takes a stream and a `finite` stream of `N` streams
- * and returns a stream where the first element from each
- * separate stream is combined into a single data event,
- * followed by the second elements of each stream and so on
- * until the shortest input stream is exhausted.
+ * and returns a stream of the corresponding `(N+1)`-tuples.
  *
  * @id zipAll
  * @section Higher-order Streams
@@ -2262,7 +2259,7 @@ exposeMethod('zipAll');
  */
 
 Stream.prototype.zip = function (ys) {
-    return this.zipAll([ys]);
+    return _([this, _(ys)]).zipAll0();
 };
 exposeMethod('zip');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2150,30 +2150,35 @@ Stream.prototype.uniq = function () {
 exposeMethod('uniq');
 
 /**
- * Takes a stream and a `finite` stream of `N` streams
- * and returns a stream where the first element from each
- * separate stream is combined into a single data event,
- * followed by the second elements of each stream and so on
- * until the shortest input stream is exhausted.
+ * Takes a `finite` stream of streams and returns a stream where the first
+ * element from each separate stream is combined into a single data event,
+ * followed by the second elements of each stream and so on until the shortest
+ * input stream is exhausted.
  *
- * @id zipAll
+ * @id zipAll0
  * @section Higher-order Streams
- * @name Stream.zipAll(ys)
- * @param {Array | Stream} ys - the array of streams to combine values with
+ * @name Stream.zipAll0()
  * @api public
  *
- * _([1,2,3]).zipAll([[4, 5, 6], [7, 8, 9], [10, 11, 12]])
+ * _([
+ *     _([1, 2, 3]),
+ *     _([4, 5, 6]),
+ *     _([7, 8, 9]),
+ *     _([10, 11, 12])
+ * ]).zipAll0()
  * // => [ [ 1, 4, 7, 10 ], [ 2, 5, 8, 11 ], [ 3, 6, 9, 12 ] ]
  *
  * // shortest stream determines length of output stream
- * _([1, 2, 3, 4]).zipAll([[5, 6, 7, 8], [9, 10, 11, 12], [13, 14]])
+ * _([
+ *     _([1, 2, 3, 4]),
+ *     _([5, 6, 7, 8]),
+ *     _([9, 10, 11, 12]),
+ *     _([13, 14])
+ * ]).zipAll0()
  * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
  */
 
-Stream.prototype.zipAll = function (ys) {
-    var self = this;
-    ys = _(ys).map(_);
-
+Stream.prototype.zipAll0 = function () {
     var returned = 0;
     var z = [];
     var finished = false;
@@ -2201,8 +2206,11 @@ Stream.prototype.zipAll = function (ys) {
         });
     }
 
-    return ys.collect().flatMap(function (array) {
-        array.unshift(self);
+    return this.map(_).collect().flatMap(function (array) {
+        if (!array.length) {
+            return _([]);
+        }
+
         return _(function (push, next) {
             returned = 0;
             z = [];
@@ -2212,6 +2220,32 @@ Stream.prototype.zipAll = function (ys) {
         });
     });
 
+};
+exposeMethod('zipAll0');
+
+/**
+ * Takes a stream and a `finite` stream of `N` streams
+ * and returns a stream where the first element from each
+ * separate stream is combined into a single data event,
+ * followed by the second elements of each stream and so on
+ * until the shortest input stream is exhausted.
+ *
+ * @id zipAll
+ * @section Higher-order Streams
+ * @name Stream.zipAll(ys)
+ * @param {Array | Stream} ys - the array of streams to combine values with
+ * @api public
+ *
+ * _([1,2,3]).zipAll([[4, 5, 6], [7, 8, 9], [10, 11, 12]])
+ * // => [ [ 1, 4, 7, 10 ], [ 2, 5, 8, 11 ], [ 3, 6, 9, 12 ] ]
+ *
+ * // shortest stream determines length of output stream
+ * _([1, 2, 3, 4]).zipAll([[5, 6, 7, 8], [9, 10, 11, 12], [13, 14]])
+ * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
+ */
+
+Stream.prototype.zipAll = function (ys) {
+    return _([this]).concat(_(ys).map(_)).zipAll0();
 };
 exposeMethod('zipAll');
 


### PR DESCRIPTION
I went with @svozza's suggestion in #263 to tack on a number to the name in the manner of `scan` and `reduce`. It's called `zipAll0` for the number of arguments.

If there's any objection to the name, speak now.