### PR TITLE
Install tape to remove warning on npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "scrawl": "0.0.5",
     "sinon": "~1.8.2",
     "stream-array": "~1.0.1",
+    "tape": "~2.4.2",
     "through": "~2.3.4",
     "transducers-js": "~0.4.135",
     "eslint": "~0.10.0"


### PR DESCRIPTION
I noticed this warning on `npm install`

```
npm WARN peerDependencies The peer dependency tape@~2.4.2 included from nodeunit-tape will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```

This change stops that warning by adding tape@~2.4.2 explicitly as a devDependency.