### PR TITLE
Add `_.batchWithTimeOrCount`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2276,7 +2276,34 @@ exposeMethod('zip');
  */
 
 Stream.prototype.batch = function (n) {
-    var batched = [];
+    return this.batchWithTimeOrCount(-1, n);
+};
+exposeMethod('batch');
+
+/**
+ * Takes one Stream and batches incoming data within a maximum time frame
+ * into arrays of a maximum length.
+ *
+ * @id batchWithTimeOrCount
+ * @section Transforms
+ * @name Stream.batchWithTimeOrCount(ms, n)
+ * @param {Number} ms - the maximum milliseconds to buffer a batch
+ * @param {Number} n - the maximum length of the array to batch
+ * @api public
+ *
+ * _(function (push) {
+ *     push(1);
+ *     push(2);
+ *     push(3);
+ *     setTimeout(push, 20, 4);
+ * }).batchWithTimeOrCount(10, 2)
+ *
+ * // => [1, 2], [3], [4]
+ */
+
+Stream.prototype.batchWithTimeOrCount = function (ms, n) {
+    var batched = [],
+        timeout;
 
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -2286,6 +2313,7 @@ Stream.prototype.batch = function (n) {
         else if (x === nil) {
             if (batched.length > 0) {
                 push(null, batched);
+                clearTimeout(timeout);
             }
 
             push(null, nil);
@@ -2296,13 +2324,20 @@ Stream.prototype.batch = function (n) {
             if (batched.length === n) {
                 push(null, batched);
                 batched = [];
+                clearTimeout(timeout);
+            }
+            else if (batched.length === 1 && ms >= 0) {
+                timeout = setTimeout(function () {
+                    push(null, batched);
+                    batched = [];
+                }, ms);
             }
 
             next();
         }
     });
 };
-exposeMethod('batch');
+exposeMethod('batchWithTimeOrCount');
 
 /**
  * Creates a new Stream with the separator interspersed between the elements of the source.


### PR DESCRIPTION
For performance, I would like to batch stream events together, but I want to be able to control latency.

My use case is with a stream of events being consumed from kafka. Instead of spamming Zookeeper with updates to the offset, I would like to do it in batches. However, I also need to protect against process crash and therefore do not want batches sitting around indefinitely waiting on another event to hit the batch size.

I struggled a lot with figuring out how to integrate this into the existing code. I came up with three options:

1. Add a optional second argument to the batch function. This would change the arity of the function, making it require a major version change.
1. Add a new function. This means you can get away with a minor revision, but seemed awkward because it is almost identical to the existing batch.
1. Make the single argument also be an options object (implemented). This isn't great because nothing else in this library follows the pattern.

Ultimately, I wasn't satisfied with any of these options. Let me know what your thoughts are. I'd happily make any changes that your request.

Thanks again for (yet another) useful library!

**Aside:** It would be useful to expose the `Stream` constructor on the exported function. That way you could easily extend it within your project without having to do something hacky like `_().constructor.prototype`.