### PR TITLE
reduce the runtime of `pick`, fixes #285

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1742,15 +1742,14 @@ var objectOnly = _.curry(function(strategy, x) {
 Stream.prototype.pickBy = function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
-        var props = [];  // cache of already seen properties
         var obj = x;  // variable used to transverse prototype chain
 
         // function created here so we don't create one per loop
-        var testAndAdd = function (prop) {
-            if (props.indexOf(prop) === -1 && f(prop, x[prop])) {
+        function testAndAdd (prop) {
+            if (!(prop in out) && f(prop, x[prop])) {
                 out[prop] = x[prop];
             }
-        };
+        }
         do {
             Object.getOwnPropertyNames(obj).forEach(testAndAdd);
             obj = Object.getPrototypeOf(obj);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1751,11 +1751,13 @@ var objectOnly = _.curry(function(strategy, x) {
 Stream.prototype.pickBy = function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
+        var seen = {};  // prevents testing overridden properties multiple times.
         var obj = x;  // variable used to traverse prototype chain
         function testAndAdd (prop) {
-            if (!(prop in out) && f(prop, x[prop])) {
+            if (!(prop in seen) && f(prop, x[prop])) {
                 out[prop] = x[prop];
             }
+            seen[prop] = true;
         }
         if (isES5) {
             do {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1719,8 +1719,10 @@ var objectOnly = _.curry(function(strategy, x) {
 
 /**
  *
- * Retrieves copies of all the enumerable elements in the collection
- * that satisfy a given predicate.
+ * Retrieves copies of all the elements in the collection
+ * that satisfy a given predicate. Note: When using ES3,
+ * only enumerable elements are selected. Both enumerable
+ * and non-enumerable elements are selected when using ES5.
  *
  * @id pickBy
  * @section Transforms
@@ -1756,7 +1758,6 @@ Stream.prototype.pickBy = function (f) {
             }
         }
         if (isES5) {
-            // function created here so we don't create one per loop
             do {
                 Object.getOwnPropertyNames(obj).forEach(testAndAdd);
                 obj = Object.getPrototypeOf(obj);
@@ -1774,7 +1775,7 @@ exposeMethod('pickBy');
 
 /**
  *
- * Retrieves copies of all enumerable elements in the collection,
+ * Retrieves copies of all elements in the collection,
  * with only the whitelisted keys. If one of the whitelisted
  * keys does not exist, it will be ignored.
  *

--- a/lib/index.js
+++ b/lib/index.js
@@ -1715,10 +1715,10 @@ var objectOnly = function(strategy, x) {
  * Retrieves copies of all the enumerable elements in the collection
  * that satisfy a given predicate.
  *
- * @id select
+ * @id pickBy
  * @section Transforms
- * @name Stream.select(f)
- * @param {Function} f - the selection strategy function
+ * @name Stream.pickBy(f)
+ * @param {Function} f - the predicate function
  * @api public
  *
  *  var dogs = [
@@ -1727,7 +1727,7 @@ var objectOnly = function(strategy, x) {
  *      {breed: 'german-shepherd', name: 'Waffles', age: 9}
  *  ];
 
- *  _(dogs).select(function (obj) {
+ *  _(dogs).pickBy(function (key, value) {
  *      return value > 4;
  *  }).toArray(function (xs) {
  *    // xs is now:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1742,11 +1742,19 @@ var objectOnly = _.curry(function(strategy, x) {
 Stream.prototype.pickBy = function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
-        for (var k in x) {
-            if (f(k, x[k])) {
-                out[k] = x[k];
+        var props = [];  // cache of already seen properties
+        var obj = x;  // variable used to transverse prototype chain
+
+        // function created here so we don't create one per loop
+        var testAndAdd = function (prop) {
+            if (props.indexOf(prop) === -1 && f(prop, x[prop])) {
+                out[prop] = x[prop];
             }
-        }
+        };
+        do {
+            Object.getOwnPropertyNames(obj).forEach(testAndAdd);
+            obj = Object.getPrototypeOf(obj);
+        } while (obj);
         return out;
     }));
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,13 @@ var _ = exports;
 var slice = Array.prototype.slice;
 var hasOwn = Object.prototype.hasOwnProperty;
 
+// ES5 detected value, used for switch between ES5 and ES3 code
+var isES5 = (function () {
+  'use strict';
+  return Function.prototype.bind && !this;
+}());
+
+
 _.isUndefined = function (x) {
     return typeof x === 'undefined';
 };
@@ -1743,17 +1750,23 @@ Stream.prototype.pickBy = function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
         var obj = x;  // variable used to transverse prototype chain
-
-        // function created here so we don't create one per loop
         function testAndAdd (prop) {
             if (!(prop in out) && f(prop, x[prop])) {
                 out[prop] = x[prop];
             }
         }
-        do {
-            Object.getOwnPropertyNames(obj).forEach(testAndAdd);
-            obj = Object.getPrototypeOf(obj);
-        } while (obj);
+        if (isES5) {
+            // function created here so we don't create one per loop
+            do {
+                Object.getOwnPropertyNames(obj).forEach(testAndAdd);
+                obj = Object.getPrototypeOf(obj);
+            } while (obj);
+        }
+        else {
+            for (var k in x) {
+                testAndAdd(k);
+            }
+        }
         return out;
     }));
 };
@@ -3981,12 +3994,6 @@ _.wrapCallback = function (f) {
  *     // data is now the contents of example.txt
  * });
  */
-
-
-var isES5 = (function () {
-  'use strict';
-  return Function.prototype.bind && !this;
-}());
 
 function isClass (fn) {
     if (!(typeof fn === 'function' && fn.prototype)) { return false; }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1698,7 +1698,7 @@ exposeMethod('pluck');
  * This helper is used in `pick` and `pickBy`
  **/
 
-var objectOnly = function(strategy, x) {
+var objectOnly = _.curry(function(strategy, x) {
     if (_.isObject(x)) {
         return strategy(x);
     }
@@ -1707,7 +1707,7 @@ var objectOnly = function(strategy, x) {
             'Expected Object, got ' + (typeof x)
         );
     }
-};
+});
 
 
 /**
@@ -1740,7 +1740,7 @@ var objectOnly = function(strategy, x) {
  */
 
 Stream.prototype.pickBy = function (f) {
-    var pickBySelection = function(x) {
+    return this.map(objectOnly(function (x) {
         var out = {};
         for (var k in x) {
             if (f(k, x[k])) {
@@ -1748,9 +1748,7 @@ Stream.prototype.pickBy = function (f) {
             }
         }
         return out;
-    };
-
-    return this.map(_.curry(objectOnly, pickBySelection));
+    }));
 };
 exposeMethod('pickBy');
 
@@ -1791,7 +1789,7 @@ exposeMethod('pickBy');
  * });*/
 
 Stream.prototype.pick = function (properties) {
-    var pickSelection = function(x) {
+    return this.map(objectOnly(function(x) {
         var out = {};
         for (var i = 0, length = properties.length; i < length; i++) {
             var p = properties[i];
@@ -1800,9 +1798,7 @@ Stream.prototype.pick = function (properties) {
             }
         }
         return out;
-    };
-
-    return this.map(_.curry(objectOnly, pickSelection));
+    }));
 };
 exposeMethod('pick');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1751,7 +1751,7 @@ var objectOnly = _.curry(function(strategy, x) {
 Stream.prototype.pickBy = function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
-        var seen = {};  // prevents testing overridden properties multiple times.
+        var seen = Object.create(null);  // prevents testing overridden properties multiple times.
         var obj = x;  // variable used to traverse prototype chain
         function testAndAdd (prop) {
             if (!(prop in seen) && f(prop, x[prop])) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1694,14 +1694,31 @@ Stream.prototype.pluck = function (prop) {
 exposeMethod('pluck');
 
 /**
+ * Only applies the transformation strategy on Objects.
+ * This helper is used in `pick` and `pickBy`
+ **/
+
+var objectOnly = function(strategy, x) {
+    if (_.isObject(x)) {
+        return strategy(x);
+    }
+    else {
+        throw new Error(
+            'Expected Object, got ' + (typeof x)
+        );
+    }
+};
+
+
+/**
  *
  * Retrieves copies of all the enumerable elements in the collection
  * that satisfy a given predicate.
  *
- * @id pickBy
+ * @id select
  * @section Transforms
- * @name Stream.pickBy(f)
- * @param {Function} f - the predicate function
+ * @name Stream.select(f)
+ * @param {Function} f - the selection strategy function
  * @api public
  *
  *  var dogs = [
@@ -1710,7 +1727,7 @@ exposeMethod('pluck');
  *      {breed: 'german-shepherd', name: 'Waffles', age: 9}
  *  ];
 
- *  _(dogs).pickBy(function (key, value) {
+ *  _(dogs).select(function (obj) {
  *      return value > 4;
  *  }).toArray(function (xs) {
  *    // xs is now:
@@ -1723,32 +1740,17 @@ exposeMethod('pluck');
  */
 
 Stream.prototype.pickBy = function (f) {
-
-    return this.consume(function (err, x, push, next) {
+    var pickBySelection = function(x) {
         var out = {};
-        if (err) {
-            push(err);
-            next();
-        }
-        else if (x === nil) {
-            push(err, x);
-        }
-        else if (_.isObject(x)) {
-            for (var k in x) {
-                if (f(k, x[k])) {
-                    out[k] = x[k];
-                }
+        for (var k in x) {
+            if (f(k, x[k])) {
+                out[k] = x[k];
             }
-            push(null, out);
-            next();
         }
-        else {
-            push(new Error(
-                'Expected Object, got ' + (typeof x)
-            ));
-            next();
-        }
-    });
+        return out;
+    };
+
+    return this.map(_.curry(objectOnly, pickBySelection));
 };
 exposeMethod('pickBy');
 
@@ -1789,14 +1791,18 @@ exposeMethod('pickBy');
  * });*/
 
 Stream.prototype.pick = function (properties) {
-    return this.pickBy(function (key) {
+    var pickSelection = function(x) {
+        var out = {};
         for (var i = 0, length = properties.length; i < length; i++) {
-            if (properties[i] === key) {
-                return true;
+            var p = properties[i];
+            if (p in x) {
+                out[p] = x[p];
             }
         }
-        return false;
-    });
+        return out;
+    };
+
+    return this.map(_.curry(objectOnly, pickSelection));
 };
 exposeMethod('pick');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1751,7 +1751,7 @@ var objectOnly = _.curry(function(strategy, x) {
 Stream.prototype.pickBy = function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
-        var obj = x;  // variable used to transverse prototype chain
+        var obj = x;  // variable used to traverse prototype chain
         function testAndAdd (prop) {
             if (!(prop in out) && f(prop, x[prop])) {
                 out[prop] = x[prop];

--- a/test/test.js
+++ b/test/test.js
@@ -3369,13 +3369,42 @@ exports['pick - non-existant property'] = function (test) {
     test.done();
 };
 
+exports['pick - non-enumerable properties'] = function (test) {
+    test.expect(5);
+    var aObj = {breed: 'labrador', 
+        name: 'Rocky',
+        owner: 'Adrian',
+        color: 'chocolate'
+    }
+    Object.defineProperty(aObj, 'age', {enumerable:false, value:12});
+    delete aObj.owner;
+    aObj.name = undefined;
+
+    var a = _([
+        aObj // <- owner delete, name undefined, age non-enumerable
+    ]);
+
+
+    a.pick(['breed', 'age', 'name', 'owner']).toArray(function (xs) {
+        test.equal(xs[0].breed, 'labrador');
+        test.equal(xs[0].age, 12);
+        test.ok(xs[0].hasOwnProperty('name'));
+        test.ok(typeof(xs[0].name) === 'undefined');
+        // neither owner nor color was selected
+        test.ok(Object.keys(xs[0]).length === 3);  
+    });
+
+
+    test.done();
+};
+
 exports['pickBy'] = function (test) {
     test.expect(4);
 
     var objs = [{a: 1, _a: 2}, {a: 1, _c: 3}];
 
-    _(objs).pickBy(function (key) {
-        return key.indexOf('_') === 0;
+    _(objs).pickBy(function (key, value) {
+        return key.indexOf('_') === 0 && typeof value !== 'function';
     }).toArray(function (xs) {
         test.deepEqual(xs, [{_a: 2}, {_c: 3}]);
     });
@@ -3408,8 +3437,8 @@ exports['pickBy'] = function (test) {
 
     var objs4 = [Object.create({a: 1, _a: 2}), {a: 1, _c: 3}];
 
-    _(objs4).pickBy(function (key) {
-        return key.indexOf('_') === 0;
+    _(objs4).pickBy(function (key, value) {
+        return key.indexOf('_') === 0 && typeof value !== 'function';
     }).toArray(function (xs) {
         test.deepEqual(xs, [{_a: 2}, {_c: 3}]);
     });
@@ -3424,8 +3453,8 @@ exports['pickBy - non-existant property'] = function (test) {
 
     var objs = [{a: 1, b: 2}, {a: 1, d: 3}];
 
-    _(objs).pickBy(function (key) {
-        return key.indexOf('_') === 0;
+    _(objs).pickBy(function (key, value) {
+        return key.indexOf('_') === 0 && typeof value !== 'function';
     }).toArray(function (xs) {
         test.deepEqual(xs, [{}, {}]);
     });
@@ -3443,14 +3472,50 @@ exports['pickBy - non-existant property'] = function (test) {
 
     var objs3 = [{}, {}];
 
-    _(objs3).pickBy(function (key) {
-        return key.indexOf('_') === 0;
+    _(objs3).pickBy(function (key, value) {
+        return key.indexOf('_') === 0 && typeof value !== 'function';
     }).toArray(function (xs) {
         test.deepEqual(xs, [{}, {}]);
     });
 
     test.done();
 };
+
+
+exports['pickBy - non-enumerable properties'] = function (test) {
+    test.expect(5);
+    var aObj = {a: 5, 
+        c: 5,
+        d: 10,
+        e: 10
+    }
+    Object.defineProperty(aObj, 'b', {enumerable:false, value:15});
+    delete aObj.c;
+    aObj.d = undefined;
+
+    var a = _([
+        aObj // <- c delete, d undefined, b non-enumerable but valid
+    ]);
+
+
+    a.pickBy(function (key, value) {
+        if (key === 'b' || value === 5 || typeof value === 'undefined') {
+            return true
+        }
+        return false
+    }).toArray(function (xs) {
+        test.equal(xs[0].a, 5);
+        test.equal(xs[0].b, 15);
+        test.ok(xs[0].hasOwnProperty('d'));
+        test.ok(typeof(xs[0].d) === 'undefined');
+        // neither c nor e was selected, b is not selected by keys
+        test.ok(Object.keys(xs[0]).length === 3);  
+    });
+
+
+    test.done();
+};
+
 
 exports['filter'] = function (test) {
     test.expect(2);

--- a/test/test.js
+++ b/test/test.js
@@ -3528,12 +3528,13 @@ exports['pickBy - non-enumerable properties'] = function (test) {
 };
 
 exports['pickBy - overridden properties'] = function (test) {
-    test.expect(6);
+    test.expect(7);
     var aObj = {
         a: 5, 
         c: 5,
         d: 10,
-        e: 10
+        e: 10,
+        valueOf: 10
     }
     var bObj = Object.create(aObj);
     bObj.b = 10;
@@ -3556,7 +3557,8 @@ exports['pickBy - overridden properties'] = function (test) {
         test.equal(xs[0].c, 10);
         test.ok(typeof(xs[0].d) === 'undefined');
         test.equal(xs[0].e, 10);
-        test.ok(Object.keys(xs[0]).length === 3);
+        test.equal(xs[0].valueOf, 10);
+        test.ok(Object.keys(xs[0]).length === 4);
     });
 
     test.done();

--- a/test/test.js
+++ b/test/test.js
@@ -3527,6 +3527,41 @@ exports['pickBy - non-enumerable properties'] = function (test) {
     test.done();
 };
 
+exports['pickBy - overridden properties'] = function (test) {
+    test.expect(6);
+    var aObj = {
+        a: 5, 
+        c: 5,
+        d: 10,
+        e: 10
+    }
+    var bObj = Object.create(aObj);
+    bObj.b = 10;
+    bObj.c = 10;
+    bObj.d = 5;
+
+    var a = _([
+        bObj
+    ]);
+
+
+    a.pickBy(function (key, value) {
+        if (value > 7) {
+            return true
+        }
+        return false
+    }).toArray(function (xs) {
+        test.ok(typeof(xs[0].a) === 'undefined');
+        test.equal(xs[0].b, 10);
+        test.equal(xs[0].c, 10);
+        test.ok(typeof(xs[0].d) === 'undefined');
+        test.equal(xs[0].e, 10);
+        test.ok(Object.keys(xs[0]).length === 3);
+    });
+
+    test.done();
+};
+
 
 exports['filter'] = function (test) {
     test.expect(2);

--- a/test/test.js
+++ b/test/test.js
@@ -3481,6 +3481,10 @@ exports['pickBy - non-existant property'] = function (test) {
     test.done();
 };
 
+var isES5 = (function () {
+  'use strict';
+  return Function.prototype.bind && !this;
+}());
 
 exports['pickBy - non-enumerable properties'] = function (test) {
     test.expect(5);
@@ -3505,13 +3509,20 @@ exports['pickBy - non-enumerable properties'] = function (test) {
         return false
     }).toArray(function (xs) {
         test.equal(xs[0].a, 5);
-        test.equal(xs[0].b, 15);
+        if (isES5) {
+            test.equal(xs[0].b, 15);
+        } else {
+            test.ok(typeof(xs[0].b) === 'undefined');
+        }
         test.ok(xs[0].hasOwnProperty('d'));
         test.ok(typeof(xs[0].d) === 'undefined');
         // neither c nor e was selected, b is not selected by keys
-        test.ok(Object.keys(xs[0]).length === 3);  
+        if (isES5) {
+            test.ok(Object.keys(xs[0]).length === 3);
+        } else {
+            test.ok(Object.keys(xs[0]).length === 2);
+        }
     });
-
 
     test.done();
 };


### PR DESCRIPTION
This is code fixes #285 

It reduces the runtime of `pick` from O(object properties * selection properties) to O(selection properties) or simply from O(nm) to O(n)

Additional bonus, pick and pickBy are now implemented using map, curry and a helper function.