### PR TITLE
Expose constructor and exposeMethod functions on the module, for plugin development

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -593,6 +593,12 @@ function exposeMethod(name) {
 }
 
 /**
+ * Expose the constructor and exposeMethod function, to allow for plugin creation
+ */
+_.Stream = Stream;
+_.exposeMethod = exposeMethod;
+
+/**
  * Used as an Error marker when writing to a Stream's incoming buffer
  */
 

--- a/test/test.js
+++ b/test/test.js
@@ -5581,3 +5581,14 @@ exports['not'] = function (test) {
     test.equal(_.not(undefined), true);
     return test.done();
 };
+
+exports['exposes functions needed for plugins'] = {
+    'constructor': function(test) {
+        test.notEqual(_.Stream, undefined);
+        return test.done();
+    },
+    'exposeMethod': function(test) {
+        test.notEqual(_.exposeMethod, undefined);
+        return test.done();
+    }
+};


### PR DESCRIPTION
Allows for some very rudimentary plugin development.

An example plugin file would look like this:

```javascript
module.exports = function(_) {
	_.Stream.prototype.sampleFunction = function sampleFunction(someArg) {
		/* Do things here. */
	}
	
	_.exposeMethod("sampleFunction");
}
```

And could be loaded as follows:

```javascript
var _ = require("highland");
require("./lib/highland-sample-plugin")(_);
```

This approach is *very* rudimentary - it won't work in a non-CommonJS environment, for example, and has no namespacing capabilities - but right now I'd say that it's better than nothing (while not causing any meaningful API bloat).