### PR TITLE
Document default argument behaviour of take and drop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2448,6 +2448,8 @@ exposeMethod('split');
 
 /**
  * Creates a new Stream with the values from the source in the range of `start` to `end`.
+ * `start` and `end` must be of type `Number`, if not the whole stream will
+ * be returned.
  *
  * @id slice
  * @section Transforms
@@ -2491,7 +2493,8 @@ Stream.prototype.slice = function(start, end) {
 exposeMethod('slice');
 
 /**
- * Creates a new Stream with the first `n` values from the source.
+ * Creates a new Stream with the first `n` values from the source. `n` must be of type `Number`,
+ * if not the whole stream will be returned.
  *
  * @id take
  * @section Transforms
@@ -2511,8 +2514,8 @@ exposeMethod('take');
 
 /**
  * Acts as the inverse of [`take(n)`](#take) - instead of returning the first `n` values, it ignores the
- * first `n` values and then emits the rest. All errors (even ones emitted before the nth value)
- * will be emitted.
+ * first `n` values and then emits the rest. `n` must be of type `Number`, if not the whole stream will
+ * be returned. All errors (even ones emitted before the nth value) will be emitted.
  *
  * @id drop
  * @section Transforms
@@ -2609,7 +2612,7 @@ exposeMethod('sortBy');
  * @name Stream.sort()
  * @api public
  *
- * var sorted = _(['b', 'z', 'g', 'r]).sort().toArray(_.log);
+ * var sorted = _(['b', 'z', 'g', 'r']).sort().toArray(_.log);
  * // => ['b', 'g', 'r', 'z']
  */
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2448,8 +2448,9 @@ exposeMethod('split');
 
 /**
  * Creates a new Stream with the values from the source in the range of `start` to `end`.
- * `start` and `end` must be of type `Number`, if not the whole stream will
- * be returned.
+ * `start` and `end` must be of type `Number`, if `start` is not a `Number` it will default to `0`
+ * and, likewise, `end` will default to `Infinity`: this could result in the whole stream being be
+ * returned.
  *
  * @id slice
  * @section Transforms


### PR DESCRIPTION
I just encountered a very nasty bug in our code in work that was revealed by the refactoring of `take` to use new `slice` function. The previous implementation had the side effect of attempting to coerce the argument it was passed in to a `Number`. The new implementation now explicitly checks to see if the argument is a `Number` and if it isn't it just returns the whole stream. 

Unfortunately there was a place in my code where I wasn't doing a `parseInt` on a parameter I was getting from a querystring that eventually got passed to `take` and it meant my stream, which unconstrained has around 200,000 elements in it, tried to process everything and brought the whole server down. I just want to document this explicitly because some people might, like me, unwittingly be depending on the previous accidental type coercion of the old version.