### PR TITLE
Make parallel throw descriptive errors on not-stream.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2980,6 +2980,9 @@ Stream.prototype.parallel = function (n) {
                 else if (x === nil) {
                     ended = true;
                 }
+                else if (!_.isStream(x)) {
+                    push(new Error('Expected Stream, got ' + (typeof x)));
+                }
                 else {
                     // got a new source, add it to the running array
                     var run = {stream: x, buffer: []};

--- a/test/test.js
+++ b/test/test.js
@@ -4978,6 +4978,15 @@ exports['parallel consumption liveness - issue #302'] = function  (test) {
     clock.tick(25);
 };
 
+
+exports['parallel - throw descriptive error on not-stream'] = function (test) {
+    test.expect(2);
+    var s = _([1]).parallel(2);
+    s.pull(errorEquals(test, 'Expected Stream, got number'));
+    s.pull(valueEquals(test, _.nil));
+    test.done();
+}
+
 exports['throttle'] = {
     setUp: function (callback) {
         this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
Apparently, `parallel` currently throws an undescriptive error along the lines of `TypeError: undefined is not a function` when applied to a stream of non-streams (see https://github.com/caolan/highland/issues/316#issuecomment-108735328). Make it emit downstream (instead of throw) a descriptive error like what `sequence` and `series` does.