### PR TITLE
add project method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1499,6 +1499,33 @@ Stream.prototype.done = function (f) {
 };
 
 /**
+ * Creates a new Stream of transformed values by projecting properties of
+ * each value from the source.
+ *
+ * @id project
+ * @section Transforms
+ * @name Stream.project(def)
+ * @param def - the definition of the projection to apply
+ * @api public
+ *
+ * var abc = _([{foo: 1, bar: 2, baz: 3}]).project({
+ *     a: 'foo',
+ *     b: 'bar'
+ * });
+ * // => {a: 1, b: 2}
+ */
+
+Stream.prototype.project = function (def) {
+    return this.map(function (x) {
+        var projected = {};
+        Object.keys(def).forEach(function (key) {
+            projected[key] = x[def[key]];
+        });
+        return projected;
+    });
+};
+
+/**
  * Creates a new Stream of transformed values by applying a function to each
  * value from the source. The transformation function can be replaced with
  * a non-function value for convenience, and it will emit that value

--- a/test/test.js
+++ b/test/test.js
@@ -3087,6 +3087,15 @@ exports['nfcall - parallel result ordering'] = function (test) {
     });
 }
 
+exports['project'] = function (test) {
+    _([
+        {foo: 1, bar: 2, baz: 3}
+    ]).project({a: 'foo', b: 'bar'}).toArray(function (xs) {
+      test.same(xs, [{a: 1, b: 2}]);
+      test.done();
+    });
+}
+
 exports['map'] = function (test) {
     test.expect(2);
     function doubled(x) {


### PR DESCRIPTION
Adds a method similar to `pick`, but implementing a more flexible projection mechanism. The name might not be optimal, could also be called `pickProj` (to hint at the similarity), or `select` (to look nice with `where`), etc.
