### PR TITLE
_checkBackPressure should cancel any repeated consume (Fixes #325).

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -710,10 +710,12 @@ Stream.prototype.pause = function () {
 
 Stream.prototype._checkBackPressure = function () {
     if (!this._consumers.length) {
+        this._repeat_resume = false;
         return this.pause();
     }
     for (var i = 0, len = this._consumers.length; i < len; i++) {
         if (this._consumers[i].paused) {
+            this._repeat_resume = false;
             return this.pause();
         }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -282,6 +282,54 @@ exports['nil should not equate to any empty object'] = function (test) {
     });
 };
 
+exports['pull'] = {
+    'pull should take one element - ArrayStream': function (test) {
+        test.expect(2);
+        var s = _([1, 2, 3]);
+        s.pull(valueEquals(test, 1));
+        s.toArray(function (xs) {
+            test.same(xs, [2, 3]);
+            test.done();
+        });
+    },
+    'pull should take one element - GeneratorStream': function (test) {
+        test.expect(2);
+        var i = 1;
+        var s = _(function (push, next) {
+            push(null, i++);
+            if (i < 4) {
+                next();
+            }
+            else {
+                push(null, _.nil);
+            }
+        });
+        s.pull(valueEquals(test, 1));
+        s.toArray(function (xs) {
+            test.same(xs, [2, 3]);
+            test.done();
+        });
+    },
+    'pull should take one element - GeneratorStream next called first (issue #325)': function (test) {
+        test.expect(2);
+        var i = 1;
+        var s = _(function (push, next) {
+            if (i < 4) {
+                next();
+            }
+            push(null, i++);
+            if (i >= 4) {
+                push(null, _.nil);
+            }
+        });
+        s.pull(valueEquals(test, 1));
+        s.toArray(function (xs) {
+            test.same(xs, [2, 3]);
+            test.done();
+        });
+    }
+};
+
 exports['async consume'] = function (test) {
     _([1,2,3,4]).consume(function (err, x, push, next) {
         if (x === _.nil) {


### PR DESCRIPTION
This seems to fix the issue @svozza found in #325, but I'm not too confident in it.

Fortunately, the 3.x engine doesn't have this bug, so we should be OK long-term.