### PR TITLE
Parallel should not drop data if paused.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2962,14 +2962,7 @@ Stream.prototype.parallel = function (n) {
     var reading_source = false;
 
     return _(function (push, next) {
-        if (running.length && running[0].buffer.length) {
-            // send buffered data
-            flushBuffer();
-            next();
-            // still waiting for more data before we can shift
-            // the running array...
-        }
-        else if (running.length < n && !ended && !reading_source) {
+        if (running.length < n && !ended && !reading_source) {
             // get another stream if not already waiting for one
             reading_source = true;
             source.pull(function (err, x) {
@@ -2994,9 +2987,7 @@ Stream.prototype.parallel = function (n) {
                                 // remove self from running and check
                                 // to see if we need to read from source again
                                 running.shift();
-                                if (running.length && running[0].buffer.length) {
-                                    flushBuffer();
-                                }
+                                flushBuffer();
                                 next();
 
                             }
@@ -3025,19 +3016,21 @@ Stream.prototype.parallel = function (n) {
         }
 
         function flushBuffer() {
-            var buf = running[0].buffer;
-            for (var i = 0; i < buf.length; i++) {
-                if (buf[i][1] === nil) {
-                    // this stream has ended
-                    running.shift();
-                    return;
+            while (running.length && running[0].buffer.length) {
+                var buf = running[0].buffer;
+                for (var i = 0; i < buf.length; i++) {
+                    if (buf[i][1] === nil) {
+                        // this stream has ended
+                        running.shift();
+                        break;
+                    }
+                    else {
+                        // send the buffered output
+                        push.apply(null, buf[i]);
+                    }
                 }
-                else {
-                    // send the buffered output
-                    push.apply(null, buf[i]);
-                }
+                buf.length = 0;
             }
-            buf.length = 0;
         }
         // else wait for more data to arrive from running streams
     });

--- a/test/test.js
+++ b/test/test.js
@@ -4987,6 +4987,28 @@ exports['parallel - throw descriptive error on not-stream'] = function (test) {
     test.done();
 }
 
+exports['parallel - parallel should not drop data if paused (issue #328)'] = function (test) {
+    test.expect(1);
+    var s1 = _([1, 2, 3]);
+    var s2 = _([11, 12, 13]);
+    _([s1.fork(), s2, s1.fork()])
+        .parallel(3)
+        .consume(function (err, x, push, next) {
+            push(err, x);
+            if (x.buf === 21) {
+                // Pause for a while.
+                setTimeout(next, 1000);
+            }
+            else if (x !== _.nil) {
+                next();
+            }
+        })
+        .toArray(function (xs) {
+            test.same(xs, [1, 2, 3, 11, 12, 13, 1, 2, 3]);
+            test.done();
+        });
+};
+
 exports['throttle'] = {
     setUp: function (callback) {
         this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
Yet another `parallel` bug.

Simplest case:

Given 3 streams `s1`, `s2`, and `s3` being consumed in this order, when s1 ends, if

* `s2` has already ended, and
* the parallel stream is paused (caused by the downstream consumer)

then anything that `s3` has already emitted gets dropped on the floor.

For those who care, the problem with the proof sketch in https://github.com/caolan/highland/pull/302#issuecomment-103325099 was the assertion

> Otherwise, when the `n`th stream ends, and it immediately flushes the buffer for the `n+1`th stream.

This is not true if the `n`th ended before one of the preceeding streams. Since it wasn't the top stream when it ended, it won't flush the buffer for the `n+1`th stream.

The fix is obviously make any stream that ends flush as much as it can (not just the next stream's data). Incidentally, this allows us to drop the flush block at the start of the generator, since it's fairly easy to show that there is never anything to flush at that point.