### PR TITLE
Extensibility 3.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2287,7 +2287,7 @@ addMethod('zipAll', function () {
  */
 
 addMethod('zipEach', function (ys) {
-    return this.create([this]).concat(this.create(ys).map(__(this.constructor))).zipAll0();
+    return this.create([this]).concat(this.create(ys).map(__(this.constructor))).zipAll();
 }, {expose: true});
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,81 +190,6 @@ var _ = exports = module.exports = function (/*optional*/xs, /*optional*/ee, /*o
         else {
             mapper = function (x) { return x; };
         }
-var _ = exports = module.exports = function (/*optional*/xs, /*optional*/ee, /*optional*/ mappingHint) {
-    /*eslint-enable no-multi-spaces */
-    var s = null;
-    if (_.isUndefined(xs)) {
-        // nothing else to do
-        s = new Stream();
-    }
-    else if (_.isStream(xs)) {
-        s = xs;
-    }
-    else if (_.isArray(xs)) {
-        s = new Stream();
-        s._outgoing.enqueueAll(xs);
-        s._outgoing.enqueue(_.nil);
-    }
-    else if (_.isFunction(xs)) {
-        s = new Stream(xs);
-    }
-
-    else if (_.isObject(xs)) {
-        // check to see if we have a readable stream
-        if (_.isFunction(xs.on) && _.isFunction(xs.pipe)) {
-            s = new Stream();
-            // write any errors into the stream
-            xs.on('error', s._push_fn);
-            xs.on('end', s.write.bind(s, _.nil));
-            // assume it's a pipeable stream as a source
-            xs.pipe(s);
-        }
-        else if (_.isFunction(xs.then)) {
-            // probably a promise
-            s = promiseStream(xs);
-        }
-        // must check iterators and iterables in this order
-        // because generators are both iterators and iterables:
-        // their Symbol.iterator method returns the `this` object
-        // and an infinite loop would result otherwise
-        else if (_.isFunction(xs.next)) {
-            //probably an iterator
-            return iteratorStream(xs);
-        }
-        else if (!_.isUndefined(_global.Symbol) && xs[_global.Symbol.iterator]) {
-            //probably an iterable
-            return iteratorStream(xs[_global.Symbol.iterator]());
-        }
-        else {
-            throw new Error(
-                'Object was not a stream, promise, iterator or iterable: ' + (typeof xs)
-            );
-        }
-    }
-    else if (_.isString(xs)) {
-        var mappingHintType = (typeof mappingHint);
-        var mapper;
-
-        if (mappingHintType === 'function') {
-            mapper = mappingHint;
-        }
-        else if (mappingHintType === 'number') {
-            mapper = function () {
-                return slice.call(arguments, 0, mappingHint);
-            };
-        }
-        else if (_.isArray(mappingHint)) {
-            mapper = function () {
-                var args = arguments;
-                return mappingHint.reduce(function (ctx, hint, idx) {
-                    ctx[hint] = args[idx];
-                    return ctx;
-                }, {});
-            };
-        }
-        else {
-            mapper = function (x) { return x; };
-        }
 
         s = new Stream();
         ee.on(xs, function () {
@@ -1039,7 +964,7 @@ _addMethod(Stream, 'destroy', function () {
 
     this.end();
     this._onEnd();
-};
+});
 
 Stream.prototype._writeOutgoing = function _writeOutgoing(token) {
     if (this.paused) {
@@ -1048,7 +973,7 @@ Stream.prototype._writeOutgoing = function _writeOutgoing(token) {
     else {
         this._send(token);
     }
-});
+};
 
 /**
  * Runs the generator function for this Stream. If the generator is already

--- a/lib/index.js
+++ b/lib/index.js
@@ -719,6 +719,37 @@ Stream._addMethod = function(name, f, options) {
     }
 };
 
+Stream._addMethods = function(methods) {
+    for (var p in methods) {
+        if (hasOwn.call(methods, p)) {
+            this._addMethod(p, methods[p], {expose: true});
+        }
+    }
+
+    return this;
+};
+
+Stream.subclass = function(methods) {
+    var Sup = this;
+    function Sub(xs, ee, mappingHint) {
+        if (!(this instanceof Sub)) {
+            return new Sub(xs, ee, mappingHint);
+        }
+
+        // Stream.apply is something else...
+        Function.prototype.apply.call(Stream, this, arguments);
+    }
+    inherits(Sub, Sup);
+    for (var p in Sup) {
+        if (hasOwn.call(Sup, p)) {
+            Sub[p] = Sup[p];
+        }
+    }
+    Sub._addMethods(methods || {});
+
+    return Sub;
+};
+
 /**
  * Used as an Error marker when writing to a Stream's incoming buffer
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -2287,7 +2287,7 @@ addMethod('zipAll', function () {
  */
 
 addMethod('zipEach', function (ys) {
-    return this.create([this]).concat(this.create(ys).map(__(this.constructor))).zipAll();
+    return this.create([this]).concat(this.create(ys).map(this.create.bind(this))).zipAll();
 }, {expose: true});
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -2737,19 +2737,19 @@ addMethod('through', function (target) {
  * });
  */
 
-_.pipeline = function (/*through...*/) {
+addToplevelMethod('pipeline', function (/*through...*/) {
     if (!arguments.length) {
-        return _();
+        return this();
     }
     var start = arguments[0], rest;
     if (!_.isStream(start) && !_.isFunction(start.resume)) {
         // not a Highland stream or Node stream, start with empty stream
-        start = _();
+        start = this();
         rest = slice.call(arguments);
     }
     else {
         // got a stream as first argument, co-erce to Highland stream
-        start = _(start);
+        start = this(start);
         rest = slice.call(arguments, 1);
     }
     var end = rest.reduce(function (src, dest) {
@@ -2775,7 +2775,7 @@ _.pipeline = function (/*through...*/) {
         start.write(token);
     };
     return wrapper;
-};
+});
 
 /**
  * Reads values from a Stream of Streams, emitting them on a single output

--- a/lib/index.js
+++ b/lib/index.js
@@ -729,7 +729,7 @@ Stream._addMethods = function(methods) {
     return this;
 };
 
-Stream.subclass = function(methods) {
+Stream.use = function(methods) {
     var Sup = this;
     function Sub(xs, ee, mappingHint) {
         if (!(this instanceof Sub)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,81 @@ var _ = exports = module.exports = function (/*optional*/xs, /*optional*/ee, /*o
         else {
             mapper = function (x) { return x; };
         }
+var _ = exports = module.exports = function (/*optional*/xs, /*optional*/ee, /*optional*/ mappingHint) {
+    /*eslint-enable no-multi-spaces */
+    var s = null;
+    if (_.isUndefined(xs)) {
+        // nothing else to do
+        s = new Stream();
+    }
+    else if (_.isStream(xs)) {
+        s = xs;
+    }
+    else if (_.isArray(xs)) {
+        s = new Stream();
+        s._outgoing.enqueueAll(xs);
+        s._outgoing.enqueue(_.nil);
+    }
+    else if (_.isFunction(xs)) {
+        s = new Stream(xs);
+    }
+
+    else if (_.isObject(xs)) {
+        // check to see if we have a readable stream
+        if (_.isFunction(xs.on) && _.isFunction(xs.pipe)) {
+            s = new Stream();
+            // write any errors into the stream
+            xs.on('error', s._push_fn);
+            xs.on('end', s.write.bind(s, _.nil));
+            // assume it's a pipeable stream as a source
+            xs.pipe(s);
+        }
+        else if (_.isFunction(xs.then)) {
+            // probably a promise
+            s = promiseStream(xs);
+        }
+        // must check iterators and iterables in this order
+        // because generators are both iterators and iterables:
+        // their Symbol.iterator method returns the `this` object
+        // and an infinite loop would result otherwise
+        else if (_.isFunction(xs.next)) {
+            //probably an iterator
+            return iteratorStream(xs);
+        }
+        else if (!_.isUndefined(_global.Symbol) && xs[_global.Symbol.iterator]) {
+            //probably an iterable
+            return iteratorStream(xs[_global.Symbol.iterator]());
+        }
+        else {
+            throw new Error(
+                'Object was not a stream, promise, iterator or iterable: ' + (typeof xs)
+            );
+        }
+    }
+    else if (_.isString(xs)) {
+        var mappingHintType = (typeof mappingHint);
+        var mapper;
+
+        if (mappingHintType === 'function') {
+            mapper = mappingHint;
+        }
+        else if (mappingHintType === 'number') {
+            mapper = function () {
+                return slice.call(arguments, 0, mappingHint);
+            };
+        }
+        else if (_.isArray(mappingHint)) {
+            mapper = function () {
+                var args = arguments;
+                return mappingHint.reduce(function (ctx, hint, idx) {
+                    ctx[hint] = args[idx];
+                    return ctx;
+                }, {});
+            };
+        }
+        else {
+            mapper = function (x) { return x; };
+        }
 
         s = new Stream();
         ee.on(xs, function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -642,20 +642,18 @@ function Stream(generator) {
 inherits(Stream, EventEmitter);
 
 function _addMethod(proto, topLevel) {
-    return function(name, f, options) {
+    return function(name, f) {
         proto[name] = f;
         var n = f.length;
-        if (options && options.expose) {
-            function relevel(coerce) {
-                return _.ncurry(n + 1, function () {
-                    var args = slice.call(arguments);
-                    var s = coerce(args.pop());
-                    return f.apply(s, args);
-                });
-            }
-            topLevel[name] = relevel(topLevel);
-            topLevel[name]._relevel = relevel;
+        function relevel(coerce) {
+            return _.ncurry(n + 1, function () {
+                var args = slice.call(arguments);
+                var s = coerce(args.pop());
+                return f.apply(s, args);
+            });
         }
+        topLevel[name] = relevel(topLevel);
+        topLevel[name]._relevel = relevel;
     };
 }
 
@@ -664,7 +662,7 @@ var addMethod = _addMethod(Stream.prototype, _);
 function _addMethods(proto, topLevel, methods) {
     for (var p in methods) {
         if (hasOwn.call(methods, p)) {
-            _addMethod(proto, topLevel)(p, methods[p], {expose: true});
+            _addMethod(proto, topLevel)(p, methods[p]);
         }
     }
 }
@@ -1159,7 +1157,7 @@ addMethod('consume', function (f) {
             }
         }
     }
-}, {expose: true});
+});
 
 /**
  * Consumes a single item from the Stream. Unlike consume, this function will
@@ -1338,7 +1336,7 @@ addMethod('errors', function (f) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Like the [errors](#errors) method, but emits a Stream end marker after
@@ -1369,7 +1367,7 @@ addMethod('stopOnError', function (f) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Iterates over every value from the Stream, calling the iterator function
@@ -1405,7 +1403,7 @@ addMethod('each', function (f) {
     });
     s.resume();
     return s;
-}, {expose: true});
+});
 
 /**
  * Applies all values from a Stream as arguments to a function. This function causes a **thunk**.
@@ -1433,7 +1431,7 @@ addMethod('apply', function (f) {
     return this.toArray(function (args) {
         f.apply(null, args);
     });
-}, {expose: true});
+});
 
 /**
  * Collects all values from a Stream into an Array and calls a function with
@@ -1575,7 +1573,7 @@ addMethod('map', function (f) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Creates a new Stream which applies a function to each value from the source
@@ -1604,7 +1602,7 @@ addMethod('doto', function (f) {
         f(x);
         return x;
     });
-}, {expose: true});
+});
 
 /**
  * An alias for the [doto](#doto) method.
@@ -1668,7 +1666,7 @@ addMethod('ratelimit', function (num, ms) {
             }
         }
     });
-}, {expose: true});
+});
 
 /**
  * Creates a new Stream of values by applying each item in a Stream to an
@@ -1686,7 +1684,7 @@ addMethod('ratelimit', function (num, ms) {
 
 addMethod('flatMap', function (f) {
     return this.map(f).sequence();
-}, {expose: true});
+});
 
 /**
  * Retrieves values associated with a given property from all elements in
@@ -1729,7 +1727,7 @@ addMethod('pluck', function (prop) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Only applies the transformation strategy on Objects.
@@ -1805,7 +1803,7 @@ addMethod('pickBy', function (f) {
         }
         return out;
     }));
-}, {expose: true});
+});
 
 /**
  *
@@ -1854,7 +1852,7 @@ addMethod('pick', function (properties) {
         }
         return out;
     }));
-}, {expose: true});
+});
 
 /**
  * Creates a new Stream including only the values which pass a truth test.
@@ -1897,7 +1895,7 @@ addMethod('filter', function (f) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Filters using a predicate which returns a Stream. If you need to check
@@ -1930,7 +1928,7 @@ addMethod('flatFilter', function (f) {
             push(null, _.nil);
         });
     }
-}, {expose: true});
+});
 
 /**
  * The inverse of [filter](#filter).
@@ -1948,7 +1946,7 @@ addMethod('flatFilter', function (f) {
 
 addMethod('reject', function (f) {
     return this.filter(_.compose(_.not, f));
-}, {expose: true});
+});
 
 /**
  * A convenient form of [filter](#filter), which returns the first object from a
@@ -1982,7 +1980,7 @@ addMethod('reject', function (f) {
 
 addMethod('find', function (f) {
     return this.filter(f).take(1);
-}, {expose: true});
+});
 
 /**
  * A convenient form of [where](#where), which returns the first object from a
@@ -2012,7 +2010,7 @@ addMethod('find', function (f) {
 
 addMethod('findWhere', function (props) {
     return this.where(props).take(1);
-}, {expose: true});
+});
 
 
 /**
@@ -2051,7 +2049,7 @@ addMethod('group', function (f) {
         m[key].push(o);
         return m;
     }, {});
-}, {expose: true});
+});
 
 /**
  * Filters a Stream to drop all non-truthy values.
@@ -2069,7 +2067,7 @@ addMethod('compact', function () {
     return this.filter(function (x) {
         return x;
     });
-}, {expose: true});
+});
 
 /**
  * A convenient form of [filter](#filter), which returns all objects from a Stream
@@ -2108,7 +2106,7 @@ addMethod('where', function (props) {
         }
         return true;
     });
-}, {expose: true});
+});
 
 /**
  * A way to keep only unique objects from a Stream
@@ -2170,7 +2168,7 @@ addMethod('uniqBy', function (compare) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Takes all unique values in a stream.
@@ -2193,7 +2191,7 @@ addMethod('uniq', function () {
     return this.uniqBy(function (a, b) {
         return a === b;
     });
-}, {expose: true});
+});
 
 /**
  * Takes a `finite` stream of streams and returns a stream where the first
@@ -2266,7 +2264,7 @@ addMethod('zipAll', function () {
         });
     });
 
-}, {expose: true});
+});
 
 /**
  * Takes a stream and a `finite` stream of `N` streams
@@ -2288,7 +2286,7 @@ addMethod('zipAll', function () {
 
 addMethod('zipEach', function (ys) {
     return this.create([this]).concat(this.create(ys).map(this.create.bind(this))).zipAll();
-}, {expose: true});
+});
 
 /**
  * Takes two Streams and returns a Stream of corresponding pairs.
@@ -2304,7 +2302,7 @@ addMethod('zipEach', function (ys) {
 
 addMethod('zip', function (ys) {
     return this.create([this, this.create(ys)]).zipAll();
-}, {expose: true});
+});
 
 /**
  * Takes one Stream and batches incoming data into arrays of given length
@@ -2320,7 +2318,7 @@ addMethod('zip', function (ys) {
 
 addMethod('batch', function (n) {
     return this.batchWithTimeOrCount(-1, n);
-}, {expose: true});
+});
 
 /**
  * Takes one Stream and batches incoming data within a maximum time frame
@@ -2378,7 +2376,7 @@ addMethod('batchWithTimeOrCount', function (ms, n) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Creates a new Stream with the separator interspersed between the elements of the source.
@@ -2417,7 +2415,7 @@ addMethod('intersperse', function (separator) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Splits the source Stream by a separator and emits the pieces in between, much like splitting a string.
@@ -2466,7 +2464,7 @@ addMethod('splitBy', function (sep) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * [splitBy](#splitBy) over newlines.
@@ -2482,7 +2480,7 @@ addMethod('splitBy', function (sep) {
 
 addMethod('split', function () {
     return this.splitBy(/\r?\n/);
-}, {expose: true});
+});
 
 /**
  * Creates a new Stream with the values from the source in the range of `start` to `end`.
@@ -2528,7 +2526,7 @@ addMethod('slice', function(start, end) {
     });
     s.id = 'slice:' + s.id;
     return s;
-}, {expose: true});
+});
 
 /**
  * Creates a new Stream with the first `n` values from the source. `n` must be of type `Number`,
@@ -2547,7 +2545,7 @@ addMethod('take', function (n) {
     var s = this.slice(0, n);
     s.id = 'take:' + s.id;
     return s;
-}, {expose: true});
+});
 
 /**
  * Acts as the inverse of [`take(n)`](#take) - instead of returning the first `n` values, it ignores the
@@ -2565,7 +2563,7 @@ addMethod('take', function (n) {
 
 addMethod('drop', function (n) {
     return this.slice(n, Infinity);
-}, {expose: true});
+});
 
 /**
  * Creates a new Stream with only the first value from the source.
@@ -2580,7 +2578,7 @@ addMethod('drop', function (n) {
 
 addMethod('head', function () {
     return this.take(1);
-}, {expose: true});
+});
 
 /**
  * Drops all values from the Stream apart from the last one (if any).
@@ -2612,7 +2610,7 @@ addMethod('last', function () {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Collects all values together then emits each value individually but in sorted order.
@@ -2634,7 +2632,7 @@ addMethod('last', function () {
 
 addMethod('sortBy', function (f) {
     return this.collect().invoke('sort', [f]).sequence();
-}, {expose: true});
+});
 
 /**
  * Collects all values together then emits each value individually but in sorted order.
@@ -2651,7 +2649,7 @@ addMethod('sortBy', function (f) {
 
 addMethod('sort', function () {
     return this.sortBy();
-}, {expose: true});
+});
 
 
 /**
@@ -2706,7 +2704,7 @@ addMethod('through', function (target) {
     function writeErr(err) {
         output.write(new StreamError(err));
     }
-}, {expose: true});
+});
 
 /**
  * Creates a 'Through Stream', which passes data through a pipeline
@@ -2864,7 +2862,7 @@ addMethod('sequence', function () {
     function onOriginalStream() {
         return curr === original;
     }
-}, {expose: true});
+});
 
 /**
  * An alias for the [sequence](#sequence) method.
@@ -2932,7 +2930,7 @@ addMethod('flatten', function () {
             }
         });
     });
-}, {expose: true});
+});
 
 /**
  * Takes a Stream of Streams and reads from them in parallel, buffering
@@ -3038,7 +3036,7 @@ addMethod('parallel', function (n) {
         }
         // else wait for more data to arrive from running streams
     });
-}, {expose: true});
+});
 
 /**
  * Switches source to an alternate Stream if the current Stream is empty.
@@ -3079,7 +3077,7 @@ addMethod('otherwise', function (ys) {
             next(xs);
         }
     });
-}, {expose: true});
+});
 
 /**
  * Adds a value to the end of a Stream.
@@ -3104,7 +3102,7 @@ addMethod('append', function (y) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Boils down a Stream to a single value. The memo is the initial state
@@ -3155,7 +3153,7 @@ addMethod('reduce', function (f, z) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Same as [reduce](#reduce), but uses the first element as the initial
@@ -3186,7 +3184,7 @@ addMethod('reduce1', function (f) {
             }
         });
     });
-}, {expose: true});
+});
 
 /**
  * Groups all values into an Array and passes down the stream as a single
@@ -3219,7 +3217,7 @@ addMethod('collect', function () {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Like [reduce](#reduce), but emits each intermediate value of the
@@ -3265,7 +3263,7 @@ addMethod('scan', function (f, z) {
             }
         })
     );
-}, {expose: true});
+});
 
 /**
  * Same as [scan](#scan), but uses the first element as the initial
@@ -3296,7 +3294,7 @@ addMethod('scan1', function (f) {
             }
         });
     });
-}, {expose: true});
+});
 
 function HighlandTransform(push) {
     this.push = push;
@@ -3401,7 +3399,7 @@ addMethod('transduce', function transduce(xf) {
             return null;
         }
     }
-}, {expose: true});
+});
 
 /**
  * Concatenates a Stream to the end of this Stream.
@@ -3431,7 +3429,7 @@ addMethod('concat', function (ys) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Takes a Stream of Streams and merges their values and errors into a
@@ -3559,7 +3557,7 @@ addMethod('merge', function () {
             }
         }
     }
-}, {expose: true});
+});
 
 /**
  * Calls a named method on each object from the Stream - returning
@@ -3581,7 +3579,7 @@ addMethod('invoke', function (method, args) {
     return this.map(function (x) {
         return x[method].apply(x, args);
     });
-}, {expose: true});
+});
 
 /**
  * Takes a Stream of callback-accepting node-style functions,
@@ -3637,7 +3635,7 @@ addMethod('nfcall', function (args) {
     return this.map(function (x) {
         return wrap(x).apply(x, args);
     });
-}, {expose: true});
+});
 
 /**
  * Ensures that only one data event is push downstream (or into the buffer)
@@ -3672,7 +3670,7 @@ addMethod('throttle', function (ms) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Holds off pushing data events downstream until there has been no more
@@ -3718,7 +3716,7 @@ addMethod('debounce', function (ms) {
             next();
         }
     });
-}, {expose: true});
+});
 
 /**
  * Creates a new Stream, which when read from, only returns the last
@@ -3792,7 +3790,7 @@ addMethod('latest', function () {
             }
         }
     });
-}, {expose: true});
+});
 
 function StreamMultiplexer(stream) {
     this._stream = stream;

--- a/lib/index.js
+++ b/lib/index.js
@@ -667,17 +667,29 @@ function _addMethods(proto, topLevel, methods) {
     }
 }
 
-function addToplevelMethod(name, fn) {
-    function relevel(topLevel) {
-        var bound = fn.bind(topLevel);
-        bound._relevel = relevel;
-        return bound;
+function _addToplevelMethod(_) {
+    return function (name, fn) {
+        function relevel(topLevel) {
+            var bound = fn.bind(topLevel);
+            bound._relevel = relevel;
+            return bound;
+        }
+        _[name] = relevel(_);
+    };
+}
+
+var addToplevelMethod = _addToplevelMethod(_);
+
+function _addToplevelMethods(topLevel, methods) {
+    for (var p in methods) {
+        if (hasOwn.call(methods, p)) {
+            _addToplevelMethod(topLevel)(p, methods[p]);
+        }
     }
-    _[name] = relevel(_);
 }
 
 function use(Super, originalTopLevel) {
-    return function(methods) {
+    return function(methods, toplevelMethods) {
         function Sub() {
             Stream.apply(this, arguments);
         }
@@ -693,6 +705,7 @@ function use(Super, originalTopLevel) {
             }
         }
         _addMethods(Sub.prototype, topLevel, methods || {});
+        _addToplevelMethods(topLevel, toplevelMethods || {});
         topLevel.use = use(Sub, topLevel);
 
         return topLevel;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2287,7 +2287,7 @@ addMethod('zipAll', function () {
  */
 
 addMethod('zipEach', function (ys) {
-    return this.create([this]).concat(_(ys).map(__(this.constructor))).zipAll0();
+    return this.create([this]).concat(this.create(ys).map(__(this.constructor))).zipAll0();
 }, {expose: true});
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -2278,7 +2278,7 @@ addMethod('zipAll', function () {
  */
 
 addMethod('zipEach', function (ys) {
-    return _([this]).concat(_(ys).map(_)).zipAll0();
+    return this.create([this]).concat(_(ys).map(__(this.constructor))).zipAll0();
 }, {expose: true});
 
 /**
@@ -2294,7 +2294,7 @@ addMethod('zipEach', function (ys) {
  */
 
 addMethod('zip', function (ys) {
-    return _([this, _(ys)]).zipAll();
+    return this.create([this, this.create(ys)]).zipAll();
 }, {expose: true});
 
 /**
@@ -2894,7 +2894,7 @@ _.series = _.sequence;
 addMethod('flatten', function () {
     var curr = this;
     var stack = [];
-    return _(function (push, next) {
+    return this.create(function (push, next) {
         curr.pull(function (err, x) {
             if (err) {
                 push(err);
@@ -2949,7 +2949,7 @@ addMethod('parallel', function (n) {
     var ended = false;
     var reading_source = false;
 
-    return _(function (push, next) {
+    return this.create(function (push, next) {
         if (running.length && running[0].buffer.length) {
             // send buffered data
             flushBuffer();
@@ -3163,7 +3163,7 @@ addMethod('reduce', function (f, z) {
 
 addMethod('reduce1', function (f) {
     var self = this;
-    return _(function (push, next) {
+    return this.create(function (push, next) {
         self.pull(function (err, x) {
             if (err) {
                 push(err);
@@ -3232,7 +3232,7 @@ addMethod('collect', function () {
 
 addMethod('scan', function (f, z) {
     var self = this;
-    return _([z]).concat(
+    return this.create([z]).concat(
         self.consume(function (err, x, push, next) {
             if (x === nil) {
                 push(null, _.nil);
@@ -3273,7 +3273,7 @@ addMethod('scan', function (f, z) {
 
 addMethod('scan1', function (f) {
     var self = this;
-    return _(function (push, next) {
+    return this.create(function (push, next) {
         self.pull(function (err, x) {
             if (err) {
                 push(err);
@@ -3454,7 +3454,7 @@ addMethod('merge', function () {
         first = true,
         async = false;
 
-    return _(function (push, next) {
+    return this.create(function (push, next) {
         if (first) {
             first = false;
             getSourcesSync(push, next);
@@ -3753,7 +3753,7 @@ addMethod('latest', function () {
         }
     }).resume();
 
-    return _(function (push, next) {
+    return this.create(function (push, next) {
         var oldErrors = errors;
         errors = [];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -706,19 +706,18 @@ function Stream(generator) {
 }
 inherits(Stream, EventEmitter);
 
-/**
- * adds a top-level _.foo(mystream) style export for Stream methods
- */
-
-function exposeMethod(name) {
-    var f = Stream.prototype[name];
+Stream._addMethod = function(name, f, options) {
+    Stream.prototype[name] = f;
     var n = f.length;
-    _[name] = _.ncurry(n + 1, function () {
-        var args = slice.call(arguments);
-        var s = _(args.pop());
-        return f.apply(s, args);
-    });
-}
+    var that = this;
+    if (options && options.expose) {
+        this[name] = _.ncurry(n + 1, function () {
+            var args = slice.call(arguments);
+            var s = that(args.pop());
+            return f.apply(s, args);
+        });
+    }
+};
 
 /**
  * Used as an Error marker when writing to a Stream's incoming buffer
@@ -835,10 +834,10 @@ Stream.prototype._onEnd = function _onEnd() {
  * xs.pause();
  */
 
-Stream.prototype.pause = function () {
+Stream._addMethod('pause', function () {
     //console.log(['pause', this.id]);
     this.paused = true;
-};
+});
 
 /*
  * Emit as many buffered token as possible, but not to exceed num.
@@ -869,7 +868,7 @@ Stream.prototype._emitNext = function (num) {
  * xs.resume();
  */
 
-Stream.prototype.resume = function () {
+Stream._addMethod('resume', function () {
     // console.log(this.id, 'resume', this.paused);
     if (!this.paused ||
             (this._consumer && this._consumer.paused) ||
@@ -896,7 +895,7 @@ Stream.prototype.resume = function () {
         // perhaps a node stream is being piped in
         this.emit('drain');
     }
-};
+});
 
 /**
  * Ends a Stream. This is the same as sending a [nil](#nil) value as data.
@@ -910,14 +909,14 @@ Stream.prototype.resume = function () {
  * @id end
  * @section Stream Objects
  * @name Stream.end()
- * @api public
+ * @aprototype.ppi public
  *
  * mystream.end();
  */
 
-Stream.prototype.end = function () {
+Stream._addMethod('end', function () {
     this.write(nil);
-};
+});
 
 /**
  * Pipes a Highland Stream to a [Node Writable Stream](http://nodejs.org/api/stream.html#stream_class_stream_writable)
@@ -942,7 +941,7 @@ Stream.prototype.end = function () {
  * source.pipe(through).pipe(dest);
  */
 
-Stream.prototype.pipe = function (dest) {
+Stream._addMethod('pipe', function (dest) {
     var self = this;
 
     // stdout and stderr are special case writables that cannot be closed
@@ -987,7 +986,7 @@ Stream.prototype.pipe = function (dest) {
             //oldResume();
         }
     }
-};
+});
 
 /**
  * Destroys a stream by unlinking it from any consumers and sources. This will
@@ -1002,7 +1001,7 @@ Stream.prototype.pipe = function (dest) {
  * @api public
  */
 
-Stream.prototype.destroy = function () {
+Stream._addMethod('destroy', function () {
     // Already destroyed.
     if (this.ended) {
         return;
@@ -1019,7 +1018,7 @@ Stream.prototype._writeOutgoing = function _writeOutgoing(token) {
     else {
         this._send(token);
     }
-};
+});
 
 /**
  * Runs the generator function for this Stream. If the generator is already
@@ -1121,7 +1120,7 @@ Stream.prototype._removeObserver = function (s) {
  * };
  */
 
-Stream.prototype.consume = function (f) {
+Stream._addMethod('consume', function (f) {
     var source = this,
         consumer;
 
@@ -1172,8 +1171,7 @@ Stream.prototype.consume = function (f) {
             }
         }
     }
-};
-exposeMethod('consume');
+}, {expose: true});
 
 /**
  * Consumes a single item from the Stream. Unlike consume, this function will
@@ -1194,7 +1192,7 @@ exposeMethod('consume');
  * });
  */
 
-Stream.prototype.pull = function (f) {
+Stream._addMethod('pull', function (f) {
     // console.log(this.id, 'pull', this._outgoing.toArray(), this.paused);
     if (this._request) {
         f(new Error('Cannot service a second pull() request while one is in progress.'));
@@ -1204,7 +1202,7 @@ Stream.prototype.pull = function (f) {
     // Don't need to pause. _send will do it for us.
     this._request = f;
     this.resume();
-};
+});
 
 /**
  * Writes a value to the Stream. If the Stream is paused it will go into the
@@ -1238,11 +1236,11 @@ Stream.prototype.pull = function (f) {
  * xs2.write(1); // This call is illegal.
  */
 
-Stream.prototype.write = function (x) {
+Stream._addMethod('write', function (x) {
     // console.log(this.id, 'write', x, this.paused);
     this._writeOutgoing(x);
     return !this.paused;
-};
+});
 
 /**
  * Forks a stream, allowing you to add additional consumers with shared
@@ -1265,7 +1263,7 @@ Stream.prototype.write = function (x) {
  * zs.resume();
  */
 
-Stream.prototype.fork = function () {
+Stream._addMethod('fork', function () {
     if (this._requests) {
         throw new Error('Cannot fork a stream with an outstanding pull() request.');
     }
@@ -1281,7 +1279,7 @@ Stream.prototype.fork = function () {
     var s = this._multiplexer.newStream();
     s.id = 'fork:' + s.id;
     return s;
-};
+});
 
 /**
  * Observes a stream, allowing you to handle values as they are emitted, without
@@ -1303,7 +1301,7 @@ Stream.prototype.fork = function () {
  * ys.resume();
  */
 
-Stream.prototype.observe = function () {
+Stream._addMethod('observe', function () {
     var s = new this.constructor();
     s.id = 'observe:' + s.id;
 
@@ -1312,7 +1310,7 @@ Stream.prototype.observe = function () {
     // s.source = this;
     this._observers.push(s);
     return s;
-};
+});
 
 /**
  * Extracts errors from a Stream and applies them to an error handler
@@ -1338,7 +1336,7 @@ Stream.prototype.observe = function () {
  * });
  */
 
-Stream.prototype.errors = function (f) {
+Stream._addMethod('errors', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             f(err, push);
@@ -1352,8 +1350,7 @@ Stream.prototype.errors = function (f) {
             next();
         }
     });
-};
-exposeMethod('errors');
+}, {expose: true});
 
 /**
  * Like the [errors](#errors) method, but emits a Stream end marker after
@@ -1370,7 +1367,7 @@ exposeMethod('errors');
  * });
  */
 
-Stream.prototype.stopOnError = function (f) {
+Stream._addMethod('stopOnError', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             f(err, push);
@@ -1384,8 +1381,7 @@ Stream.prototype.stopOnError = function (f) {
             next();
         }
     });
-};
-exposeMethod('stopOnError');
+}, {expose: true});
 
 /**
  * Iterates over every value from the Stream, calling the iterator function
@@ -1405,7 +1401,7 @@ exposeMethod('stopOnError');
  * });
  */
 
-Stream.prototype.each = function (f) {
+Stream._addMethod('each', function (f) {
     var self = this;
     var s = this.consume(function (err, x, push, next) {
         if (err) {
@@ -1421,8 +1417,7 @@ Stream.prototype.each = function (f) {
     });
     s.resume();
     return s;
-};
-exposeMethod('each');
+}, {expose: true});
 
 /**
  * Applies all values from a Stream as arguments to a function. This function causes a **thunk**.
@@ -1446,12 +1441,11 @@ exposeMethod('each');
  * });
  */
 
-Stream.prototype.apply = function (f) {
+Stream._addMethod('apply', function (f) {
     return this.toArray(function (args) {
         f.apply(null, args);
     });
-};
-exposeMethod('apply');
+}, {expose: true});
 
 /**
  * Collects all values from a Stream into an Array and calls a function with
@@ -1471,7 +1465,7 @@ exposeMethod('apply');
  * });
  */
 
-Stream.prototype.toArray = function (f) {
+Stream._addMethod('toArray', function (f) {
     var self = this;
     return this.collect().pull(function (err, x) {
         if (err) {
@@ -1481,7 +1475,7 @@ Stream.prototype.toArray = function (f) {
             f(x);
         }
     });
-};
+});
 
 /**
  * Calls a function once the Stream has ended. This function causes a **thunk**.
@@ -1504,7 +1498,7 @@ Stream.prototype.toArray = function (f) {
  * });
  */
 
-Stream.prototype.done = function (f) {
+Stream._addMethod('done', function (f) {
     if (this.ended) {
         f();
         return null;
@@ -1521,7 +1515,7 @@ Stream.prototype.done = function (f) {
             next();
         }
     }).resume();
-};
+});
 
 /**
  * Registers a callback that will be called when the stream is destroyed.
@@ -1566,7 +1560,7 @@ Stream.prototype.onDestroy = function onDestroy(f) {
  * _([1, 2, 3]).map('hi')  // => 'hi', 'hi', 'hi'
  */
 
-Stream.prototype.map = function (f) {
+Stream._addMethod('map', function (f) {
     if (!_.isFunction(f)) {
         var val = f;
         f = function () {
@@ -1593,8 +1587,7 @@ Stream.prototype.map = function (f) {
             next();
         }
     });
-};
-exposeMethod('map');
+}, {expose: true});
 
 /**
  * Creates a new Stream which applies a function to each value from the source
@@ -1618,13 +1611,12 @@ exposeMethod('map');
  * // => 1, 2, 3
  */
 
-Stream.prototype.doto = function (f) {
+Stream._addMethod('doto', function (f) {
     return this.map(function (x) {
         f(x);
         return x;
     });
-};
-exposeMethod('doto');
+}, {expose: true});
 
 /**
  * An alias for the [doto](#doto) method.
@@ -1660,7 +1652,7 @@ _.tap = _.doto;
  * // after 200ms => 1, 2, 3, 4, 5
  */
 
-Stream.prototype.ratelimit = function (num, ms) {
+Stream._addMethod('ratelimit', function (num, ms) {
     if (num < 1) {
         throw new Error('Invalid number of operations per ms: ' + num);
     }
@@ -1688,8 +1680,7 @@ Stream.prototype.ratelimit = function (num, ms) {
             }
         }
     });
-};
-exposeMethod('ratelimit');
+}, {expose: true});
 
 /**
  * Creates a new Stream of values by applying each item in a Stream to an
@@ -1705,10 +1696,9 @@ exposeMethod('ratelimit');
  * filenames.flatMap(readFile)
  */
 
-Stream.prototype.flatMap = function (f) {
+Stream._addMethod('flatMap', function (f) {
     return this.map(f).sequence();
-};
-exposeMethod('flatMap');
+}, {expose: true});
 
 /**
  * Retrieves values associated with a given property from all elements in
@@ -1731,7 +1721,7 @@ exposeMethod('flatMap');
  * });
  */
 
-Stream.prototype.pluck = function (prop) {
+Stream._addMethod('pluck', function (prop) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             push(err);
@@ -1751,8 +1741,7 @@ Stream.prototype.pluck = function (prop) {
             next();
         }
     });
-};
-exposeMethod('pluck');
+}, {expose: true});
 
 /**
  * Only applies the transformation strategy on Objects.
@@ -1802,7 +1791,7 @@ var objectOnly = _.curry(function(strategy, x) {
  *  });
  */
 
-Stream.prototype.pickBy = function (f) {
+Stream._addMethod('pickBy', function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
 
@@ -1828,8 +1817,7 @@ Stream.prototype.pickBy = function (f) {
         }
         return out;
     }));
-};
-exposeMethod('pickBy');
+}, {expose: true});
 
 /**
  *
@@ -1867,7 +1855,7 @@ exposeMethod('pickBy');
  *      ]
  * });*/
 
-Stream.prototype.pick = function (properties) {
+Stream._addMethod('pick', function (properties) {
     return this.map(objectOnly(function(x) {
         var out = {};
         for (var i = 0, length = properties.length; i < length; i++) {
@@ -1878,8 +1866,7 @@ Stream.prototype.pick = function (properties) {
         }
         return out;
     }));
-};
-exposeMethod('pick');
+}, {expose: true});
 
 /**
  * Creates a new Stream including only the values which pass a truth test.
@@ -1895,7 +1882,7 @@ exposeMethod('pick');
  * });
  */
 
-Stream.prototype.filter = function (f) {
+Stream._addMethod('filter', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             push(err);
@@ -1922,8 +1909,7 @@ Stream.prototype.filter = function (f) {
             next();
         }
     });
-};
-exposeMethod('filter');
+}, {expose: true});
 
 /**
  * Filters using a predicate which returns a Stream. If you need to check
@@ -1942,7 +1928,7 @@ exposeMethod('filter');
  * filenames.flatFilter(checkExists)
  */
 
-Stream.prototype.flatFilter = function (f) {
+Stream._addMethod('flatFilter', function (f) {
     return this.flatMap(function (x) {
         return f(x).take(1).otherwise(errorStream())
         .flatMap(function (bool) {
@@ -1956,8 +1942,7 @@ Stream.prototype.flatFilter = function (f) {
             push(null, _.nil);
         });
     }
-};
-exposeMethod('flatFilter');
+}, {expose: true});
 
 /**
  * The inverse of [filter](#filter).
@@ -1973,10 +1958,9 @@ exposeMethod('flatFilter');
  * });
  */
 
-Stream.prototype.reject = function (f) {
+Stream._addMethod('reject', function (f) {
     return this.filter(_.compose(_.not, f));
-};
-exposeMethod('reject');
+}, {expose: true});
 
 /**
  * A convenient form of [filter](#filter), which returns the first object from a
@@ -2008,10 +1992,9 @@ exposeMethod('reject');
  * // => {type: 'blogpost', title: 'foo'}
  */
 
-Stream.prototype.find = function (f) {
+Stream._addMethod('find', function (f) {
     return this.filter(f).take(1);
-};
-exposeMethod('find');
+}, {expose: true});
 
 /**
  * A convenient form of [where](#where), which returns the first object from a
@@ -2039,10 +2022,9 @@ exposeMethod('find');
  * // => {type: 'blogpost', title: 'foo'}
  */
 
-Stream.prototype.findWhere = function (props) {
+Stream._addMethod('findWhere', function (props) {
     return this.where(props).take(1);
-};
-exposeMethod('findWhere');
+}, {expose: true});
 
 
 /**
@@ -2073,7 +2055,7 @@ exposeMethod('findWhere');
  *
  */
 
-Stream.prototype.group = function (f) {
+Stream._addMethod('group', function (f) {
     var lambda = _.isString(f) ? _.get(f) : f;
     return this.reduce(function (m, o) {
         var key = lambda(o);
@@ -2081,8 +2063,7 @@ Stream.prototype.group = function (f) {
         m[key].push(o);
         return m;
     }, {});
-};
-exposeMethod('group');
+}, {expose: true});
 
 /**
  * Filters a Stream to drop all non-truthy values.
@@ -2096,12 +2077,11 @@ exposeMethod('group');
  * // => 1, 3, 6
  */
 
-Stream.prototype.compact = function () {
+Stream._addMethod('compact', function () {
     return this.filter(function (x) {
         return x;
     });
-};
-exposeMethod('compact');
+}, {expose: true});
 
 /**
  * A convenient form of [filter](#filter), which returns all objects from a Stream
@@ -2131,7 +2111,7 @@ exposeMethod('compact');
  * // => {type: 'blogpost', title: 'bar'}
  */
 
-Stream.prototype.where = function (props) {
+Stream._addMethod('where', function (props) {
     return this.filter(function (x) {
         for (var k in props) {
             if (x[k] !== props[k]) {
@@ -2140,8 +2120,7 @@ Stream.prototype.where = function (props) {
         }
         return true;
     });
-};
-exposeMethod('where');
+}, {expose: true});
 
 /**
  * A way to keep only unique objects from a Stream
@@ -2168,7 +2147,7 @@ exposeMethod('where');
  *
  */
 
-Stream.prototype.uniqBy = function (compare) {
+Stream._addMethod('uniqBy', function (compare) {
     var uniques = [];
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -2203,8 +2182,7 @@ Stream.prototype.uniqBy = function (compare) {
             next();
         }
     });
-};
-exposeMethod('uniqBy');
+}, {expose: true});
 
 /**
  * Takes all unique values in a stream.
@@ -2223,12 +2201,11 @@ exposeMethod('uniqBy');
  * // => 'yellow'
  */
 
-Stream.prototype.uniq = function () {
+Stream._addMethod('uniq', function () {
     return this.uniqBy(function (a, b) {
         return a === b;
     });
-};
-exposeMethod('uniq');
+}, {expose: true});
 
 /**
  * Takes a `finite` stream of streams and returns a stream where the first
@@ -2259,7 +2236,7 @@ exposeMethod('uniq');
  * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
  */
 
-Stream.prototype.zipAll = function () {
+Stream._addMethod('zipAll', function () {
     var returned = 0;
     var z = [];
     var finished = false;
@@ -2301,8 +2278,7 @@ Stream.prototype.zipAll = function () {
         });
     });
 
-};
-exposeMethod('zipAll');
+}, {expose: true});
 
 /**
  * Takes a stream and a `finite` stream of `N` streams
@@ -2322,10 +2298,9 @@ exposeMethod('zipAll');
  * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
  */
 
-Stream.prototype.zipEach = function (ys) {
-    return _([this]).concat(_(ys).map(_)).zipAll();
-};
-exposeMethod('zipEach');
+Stream._addMethod('zipEach', function (ys) {
+    return _([this]).concat(_(ys).map(_)).zipAll0();
+}, {expose: true});
 
 /**
  * Takes two Streams and returns a Stream of corresponding pairs.
@@ -2339,10 +2314,9 @@ exposeMethod('zipEach');
  * _(['a', 'b', 'c']).zip([1, 2, 3])  // => ['a', 1], ['b', 2], ['c', 3]
  */
 
-Stream.prototype.zip = function (ys) {
+Stream._addMethod('zip', function (ys) {
     return _([this, _(ys)]).zipAll();
-};
-exposeMethod('zip');
+}, {expose: true});
 
 /**
  * Takes one Stream and batches incoming data into arrays of given length
@@ -2356,10 +2330,9 @@ exposeMethod('zip');
  * _([1, 2, 3, 4, 5]).batch(2)  // => [1, 2], [3, 4], [5]
  */
 
-Stream.prototype.batch = function (n) {
+Stream._addMethod('batch', function (n) {
     return this.batchWithTimeOrCount(-1, n);
-};
-exposeMethod('batch');
+}, {expose: true});
 
 /**
  * Takes one Stream and batches incoming data within a maximum time frame
@@ -2382,7 +2355,7 @@ exposeMethod('batch');
  * // => [1, 2], [3], [4]
  */
 
-Stream.prototype.batchWithTimeOrCount = function (ms, n) {
+Stream._addMethod('batchWithTimeOrCount', function (ms, n) {
     var batched = [],
         timeout;
 
@@ -2417,8 +2390,7 @@ Stream.prototype.batchWithTimeOrCount = function (ms, n) {
             next();
         }
     });
-};
-exposeMethod('batchWithTimeOrCount');
+}, {expose: true});
 
 /**
  * Creates a new Stream with the separator interspersed between the elements of the source.
@@ -2436,7 +2408,7 @@ exposeMethod('batchWithTimeOrCount');
  * _(['foo']).intersperse('bar')  // => foo
  */
 
-Stream.prototype.intersperse = function (separator) {
+Stream._addMethod('intersperse', function (separator) {
     var started = false;
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -2457,8 +2429,7 @@ Stream.prototype.intersperse = function (separator) {
             next();
         }
     });
-};
-exposeMethod('intersperse');
+}, {expose: true});
 
 /**
  * Splits the source Stream by a separator and emits the pieces in between, much like splitting a string.
@@ -2476,7 +2447,7 @@ exposeMethod('intersperse');
  * _(['foo']).splitBy('bar')  // => foo
  */
 
-Stream.prototype.splitBy = function (sep) {
+Stream._addMethod('splitBy', function (sep) {
     var decoder = new Decoder();
     var buffer = false;
 
@@ -2507,8 +2478,7 @@ Stream.prototype.splitBy = function (sep) {
             next();
         }
     });
-};
-exposeMethod('splitBy');
+}, {expose: true});
 
 /**
  * [splitBy](#splitBy) over newlines.
@@ -2522,10 +2492,9 @@ exposeMethod('splitBy');
  * _(['a\r\nb\nc']]).split()  // => a, b, c
  */
 
-Stream.prototype.split = function () {
+Stream._addMethod('split', function () {
     return this.splitBy(/\r?\n/);
-};
-exposeMethod('split');
+}, {expose: true});
 
 /**
  * Creates a new Stream with the values from the source in the range of `start` to `end`.
@@ -2543,7 +2512,7 @@ exposeMethod('split');
  * _([1, 2, 3, 4]).slice(1, 3) // => 2, 3
  */
 
-Stream.prototype.slice = function(start, end) {
+Stream._addMethod('slice', function(start, end) {
     var index = 0;
     start = typeof start != 'number' || start < 0 ? 0 : start;
     end = typeof end != 'number' ? Infinity : end;
@@ -2571,8 +2540,7 @@ Stream.prototype.slice = function(start, end) {
     });
     s.id = 'slice:' + s.id;
     return s;
-};
-exposeMethod('slice');
+}, {expose: true});
 
 /**
  * Creates a new Stream with the first `n` values from the source. `n` must be of type `Number`,
@@ -2587,12 +2555,11 @@ exposeMethod('slice');
  * _([1, 2, 3, 4]).take(2) // => 1, 2
  */
 
-Stream.prototype.take = function (n) {
+Stream._addMethod('take', function (n) {
     var s = this.slice(0, n);
     s.id = 'take:' + s.id;
     return s;
-};
-exposeMethod('take');
+}, {expose: true});
 
 /**
  * Acts as the inverse of [`take(n)`](#take) - instead of returning the first `n` values, it ignores the
@@ -2608,10 +2575,9 @@ exposeMethod('take');
  * _([1, 2, 3, 4]).drop(2) // => 3, 4
  */
 
-Stream.prototype.drop = function (n) {
+Stream._addMethod('drop', function (n) {
     return this.slice(n, Infinity);
-};
-exposeMethod('drop');
+}, {expose: true});
 
 /**
  * Creates a new Stream with only the first value from the source.
@@ -2624,10 +2590,9 @@ exposeMethod('drop');
  * _([1, 2, 3, 4]).head() // => 1
  */
 
-Stream.prototype.head = function () {
+Stream._addMethod('head', function () {
     return this.take(1);
-};
-exposeMethod('head');
+}, {expose: true});
 
 /**
  * Drops all values from the Stream apart from the last one (if any).
@@ -2640,7 +2605,7 @@ exposeMethod('head');
  * _([1, 2, 3, 4]).last()  // => 4
  */
 
-Stream.prototype.last = function () {
+Stream._addMethod('last', function () {
     var nothing = {};
     var prev = nothing;
     return this.consume(function (err, x, push, next) {
@@ -2659,8 +2624,7 @@ Stream.prototype.last = function () {
             next();
         }
     });
-};
-exposeMethod('last');
+}, {expose: true});
 
 /**
  * Collects all values together then emits each value individually but in sorted order.
@@ -2680,10 +2644,9 @@ exposeMethod('last');
  * //=> [4, 3, 2, 1]
  */
 
-Stream.prototype.sortBy = function (f) {
+Stream._addMethod('sortBy', function (f) {
     return this.collect().invoke('sort', [f]).sequence();
-};
-exposeMethod('sortBy');
+}, {expose: true});
 
 /**
  * Collects all values together then emits each value individually but in sorted order.
@@ -2698,10 +2661,9 @@ exposeMethod('sortBy');
  * // => ['b', 'g', 'r', 'z']
  */
 
-Stream.prototype.sort = function () {
+Stream._addMethod('sort', function () {
     return this.sortBy();
-};
-exposeMethod('sort');
+}, {expose: true});
 
 
 /**
@@ -2739,7 +2701,7 @@ exposeMethod('sort');
  * });
  */
 
-Stream.prototype.through = function (target) {
+Stream._addMethod('through', function (target) {
     var output;
 
     if (_.isFunction(target)) {
@@ -2756,8 +2718,7 @@ Stream.prototype.through = function (target) {
     function writeErr(err) {
         output.write(new StreamError(err));
     }
-};
-exposeMethod('through');
+}, {expose: true});
 
 /**
  * Creates a 'Through Stream', which passes data through a pipeline
@@ -2833,7 +2794,7 @@ _.pipeline = function (/*through...*/) {
  * filenames.map(readFile).sequence()
  */
 
-Stream.prototype.sequence = function () {
+Stream._addMethod('sequence', function () {
     var original = this;
     var curr = this;
     return _(function (push, next) {
@@ -2896,8 +2857,7 @@ Stream.prototype.sequence = function () {
     function onOriginalStream() {
         return curr === original;
     }
-};
-exposeMethod('sequence');
+}, {expose: true});
 
 /**
  * An alias for the [sequence](#sequence) method.
@@ -2933,7 +2893,7 @@ _.series = _.sequence;
  * nums.flatten();  // => 1, 2, 3, 4, 5, 6
  */
 
-Stream.prototype.flatten = function () {
+Stream._addMethod('flatten', function () {
     var curr = this;
     var stack = [];
     return _(function (push, next) {
@@ -2965,8 +2925,7 @@ Stream.prototype.flatten = function () {
             }
         });
     });
-};
-exposeMethod('flatten');
+}, {expose: true});
 
 /**
  * Takes a Stream of Streams and reads from them in parallel, buffering
@@ -2986,7 +2945,7 @@ exposeMethod('flatten');
  * filenames.map(readFile).parallel(10);
  */
 
-Stream.prototype.parallel = function (n) {
+Stream._addMethod('parallel', function (n) {
     var source = this;
     var running = [];
     var ended = false;
@@ -3072,8 +3031,7 @@ Stream.prototype.parallel = function (n) {
         }
         // else wait for more data to arrive from running streams
     });
-};
-exposeMethod('parallel');
+}, {expose: true});
 
 /**
  * Switches source to an alternate Stream if the current Stream is empty.
@@ -3091,7 +3049,7 @@ exposeMethod('parallel');
  * _.otherwise(_(['foo']), _([]))         // => 'foo'
  */
 
-Stream.prototype.otherwise = function (ys) {
+Stream._addMethod('otherwise', function (ys) {
     var xs = this;
     return xs.consume(function (err, x, push, next) {
         if (err) {
@@ -3114,8 +3072,7 @@ Stream.prototype.otherwise = function (ys) {
             next(xs);
         }
     });
-};
-exposeMethod('otherwise');
+}, {expose: true});
 
 /**
  * Adds a value to the end of a Stream.
@@ -3129,7 +3086,7 @@ exposeMethod('otherwise');
  * _([1, 2, 3]).append(4)  // => 1, 2, 3, 4
  */
 
-Stream.prototype.append = function (y) {
+Stream._addMethod('append', function (y) {
     return this.consume(function (err, x, push, next) {
         if (x === nil) {
             push(null, y);
@@ -3140,8 +3097,7 @@ Stream.prototype.append = function (y) {
             next();
         }
     });
-};
-exposeMethod('append');
+}, {expose: true});
 
 /**
  * Boils down a Stream to a single value. The memo is the initial state
@@ -3166,7 +3122,7 @@ exposeMethod('append');
  * _([1, 2, 3, 4]).reduce(add, 0)  // => 10
  */
 
-Stream.prototype.reduce = function (f, z) {
+Stream._addMethod('reduce', function (f, z) {
     // This can't be implemented with scan(), because we don't know if the
     // errors that we see from the scan were thrown by the iterator or just
     // passed through from the source stream.
@@ -3192,8 +3148,7 @@ Stream.prototype.reduce = function (f, z) {
             next();
         }
     });
-};
-exposeMethod('reduce');
+}, {expose: true});
 
 /**
  * Same as [reduce](#reduce), but uses the first element as the initial
@@ -3208,7 +3163,7 @@ exposeMethod('reduce');
  * _([1, 2, 3, 4]).reduce1(add)  // => 10
  */
 
-Stream.prototype.reduce1 = function (f) {
+Stream._addMethod('reduce1', function (f) {
     var self = this;
     return _(function (push, next) {
         self.pull(function (err, x) {
@@ -3224,8 +3179,7 @@ Stream.prototype.reduce1 = function (f) {
             }
         });
     });
-};
-exposeMethod('reduce1');
+}, {expose: true});
 
 /**
  * Groups all values into an Array and passes down the stream as a single
@@ -3242,7 +3196,7 @@ exposeMethod('reduce1');
  * });
  */
 
-Stream.prototype.collect = function () {
+Stream._addMethod('collect', function () {
     var xs = [];
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -3258,8 +3212,7 @@ Stream.prototype.collect = function () {
             next();
         }
     });
-};
-exposeMethod('collect');
+}, {expose: true});
 
 /**
  * Like [reduce](#reduce), but emits each intermediate value of the
@@ -3279,7 +3232,7 @@ exposeMethod('collect');
  * _([1, 2, 3, 4]).scan(add, 0)  // => 0, 1, 3, 6, 10
  */
 
-Stream.prototype.scan = function (f, z) {
+Stream._addMethod('scan', function (f, z) {
     var self = this;
     return _([z]).concat(
         self.consume(function (err, x, push, next) {
@@ -3305,8 +3258,7 @@ Stream.prototype.scan = function (f, z) {
             }
         })
     );
-};
-exposeMethod('scan');
+}, {expose: true});
 
 /**
  * Same as [scan](#scan), but uses the first element as the initial
@@ -3321,7 +3273,7 @@ exposeMethod('scan');
  * _([1, 2, 3, 4]).scan1(add)  // => 1, 3, 6, 10
  */
 
-Stream.prototype.scan1 = function (f) {
+Stream._addMethod('scan1', function (f) {
     var self = this;
     return _(function (push, next) {
         self.pull(function (err, x) {
@@ -3337,8 +3289,7 @@ Stream.prototype.scan1 = function (f) {
             }
         });
     });
-};
-exposeMethod('scan1');
+}, {expose: true});
 
 function HighlandTransform(push) {
     this.push = push;
@@ -3386,7 +3337,7 @@ HighlandTransform.prototype['@@transducer/step'] = function (push, input) {
  * // => [2, 3, 4, 5]
  */
 
-Stream.prototype.transduce = function transduce(xf) {
+Stream._addMethod('transduce', function transduce(xf) {
     var transform = null,
         memo = null;
 
@@ -3443,8 +3394,7 @@ Stream.prototype.transduce = function transduce(xf) {
             return null;
         }
     }
-};
-exposeMethod('transduce');
+}, {expose: true});
 
 /**
  * Concatenates a Stream to the end of this Stream.
@@ -3463,7 +3413,7 @@ exposeMethod('transduce');
  * _.concat([3, 4], [1, 2])  // => 1, 2, 3, 4
  */
 
-Stream.prototype.concat = function (ys) {
+Stream._addMethod('concat', function (ys) {
     ys = _(ys);
     return this.consume(function (err, x, push, next) {
         if (x === nil) {
@@ -3474,8 +3424,7 @@ Stream.prototype.concat = function (ys) {
             next();
         }
     });
-};
-exposeMethod('concat');
+}, {expose: true});
 
 /**
  * Takes a Stream of Streams and merges their values and errors into a
@@ -3499,7 +3448,7 @@ exposeMethod('concat');
  * // => contents of foo.txt, bar.txt and baz.txt in the order they were read
  */
 
-Stream.prototype.merge = function () {
+Stream._addMethod('merge', function () {
     var self = this;
     var srcs = [];
 
@@ -3603,8 +3552,7 @@ Stream.prototype.merge = function () {
             }
         }
     }
-};
-exposeMethod('merge');
+}, {expose: true});
 
 /**
  * Calls a named method on each object from the Stream - returning
@@ -3622,12 +3570,11 @@ exposeMethod('merge');
  * filenames.map(readFile).sequence().invoke('toString', ['utf8']);
  */
 
-Stream.prototype.invoke = function (method, args) {
+Stream._addMethod('invoke', function (method, args) {
     return this.map(function (x) {
         return x[method].apply(x, args);
     });
-};
-exposeMethod('invoke');
+}, {expose: true});
 
 /**
  * Takes a Stream of callback-accepting node-style functions,
@@ -3678,12 +3625,11 @@ exposeMethod('invoke');
  *
  */
 
-Stream.prototype.nfcall = function (args) {
+Stream._addMethod('nfcall', function (args) {
     return this.map(function (x) {
         return _.wrapCallback(x).apply(x, args);
     });
-};
-exposeMethod('nfcall');
+}, {expose: true});
 
 /**
  * Ensures that only one data event is push downstream (or into the buffer)
@@ -3698,7 +3644,7 @@ exposeMethod('nfcall');
  * _('mousemove', document).throttle(1000);
  */
 
-Stream.prototype.throttle = function (ms) {
+Stream._addMethod('throttle', function (ms) {
     var last = 0 - ms;
     return this.consume(function (err, x, push, next) {
         var now = new Date().getTime();
@@ -3718,8 +3664,7 @@ Stream.prototype.throttle = function (ms) {
             next();
         }
     });
-};
-exposeMethod('throttle');
+}, {expose: true});
 
 /**
  * Holds off pushing data events downstream until there has been no more
@@ -3736,7 +3681,7 @@ exposeMethod('throttle');
  * $('keyup', textbox).debounce(1000);
  */
 
-Stream.prototype.debounce = function (ms) {
+Stream._addMethod('debounce', function (ms) {
     var t = null;
     var nothing = {};
     var last = nothing;
@@ -3765,8 +3710,7 @@ Stream.prototype.debounce = function (ms) {
             next();
         }
     });
-};
-exposeMethod('debounce');
+}, {expose: true});
 
 /**
  * Creates a new Stream, which when read from, only returns the last
@@ -3784,7 +3728,7 @@ exposeMethod('debounce');
  * mousePosition.latest().map(slowThing)
  */
 
-Stream.prototype.latest = function () {
+Stream._addMethod('latest', function () {
     var nothing = {},
         latest = nothing,
         errors = [],
@@ -3840,8 +3784,7 @@ Stream.prototype.latest = function () {
             }
         }
     });
-};
-exposeMethod('latest');
+}, {expose: true});
 
 function PipelineWrapperStream(start, end) {
     var self = this;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2827,7 +2827,7 @@ _.pipeline = function (/*through...*/) {
 _addMethod(Stream, 'sequence', function () {
     var original = this;
     var curr = this;
-    return _(function (push, next) {
+    return new this.constructor(function (push, next) {
         curr.pull(function (err, x) {
             if (err) {
                 push(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1161,7 +1161,7 @@ addMethod('consume', function (f) {
 
 /**
  * Consumes a single item from the Stream. Unlike consume, this function will
- * not provide a n/ew stream for you to push values onto, and it will unsubscribe
+ * not provide a new stream for you to push values onto, and it will unsubscribe
  * as soon as it has a single error, value or nil from the source.
  *
  * You probably won't need to use this directly, but it is used internally by

--- a/lib/index.js
+++ b/lib/index.js
@@ -669,6 +669,15 @@ function _addMethods(proto, topLevel, methods) {
     }
 }
 
+function addToplevelMethod(name, fn) {
+    function relevel(topLevel) {
+        var bound = fn.bind(topLevel);
+        bound._relevel = relevel;
+        return bound;
+    }
+    _[name] = relevel(_);
+}
+
 function use(Super, originalTopLevel) {
     return function(methods) {
         function Sub() {
@@ -4089,11 +4098,12 @@ _.log = function () {
  * Reader.prototype.readStream = _.wrapCallback(Reader.prototype.read);
  */
 
-_.wrapCallback = function (f) {
+addToplevelMethod('wrapCallback', function (f) {
+    var stream = this;
     return function () {
         var self = this;
         var args = slice.call(arguments);
-        return _(function (push) {
+        return stream(function (push) {
             var cb = function (err, x) {
                 if (err) {
                     push(err);
@@ -4106,7 +4116,7 @@ _.wrapCallback = function (f) {
             f.apply(self, args.concat([cb]));
         });
     };
-};
+});
 
 /**
  * Takes an object or a constructor function and returns that object or
@@ -4151,7 +4161,7 @@ function inheritedKeys (obj) {
     return keys(allProps);
 }
 
-function streamifyAll (inp, suffix) {
+function streamifyAll (wrapCallback, inp, suffix) {
     // will not streamify inherited functions in ES3
     var getKeys = isES5 ? inheritedKeys : keys;
     var allKeys = getKeys(inp);
@@ -4170,7 +4180,7 @@ function streamifyAll (inp, suffix) {
         if (val && typeof val === 'function' && !isClass(val) &&
                 !val.__HighlandStreamifiedFunction__) {
 
-            var streamified = _.wrapCallback(val);
+            var streamified = wrapCallback(val);
             streamified.__HighlandStreamifiedFunction__ = true;
             inp[key + suffix] = streamified;
         }
@@ -4178,18 +4188,18 @@ function streamifyAll (inp, suffix) {
     return inp;
 }
 
-_.streamifyAll = function (arg) {
+addToplevelMethod('streamifyAll', function (arg) {
     if (typeof arg !== 'function' && typeof arg !== 'object') {
         throw new TypeError('takes an object or a constructor function');
     }
     var suffix = 'Stream';
 
-    var ret = streamifyAll(arg, suffix);
+    var ret = streamifyAll(this.wrapCallback, arg, suffix);
     if (isClass(arg)) {
-        ret.prototype = streamifyAll(arg.prototype, suffix);
+        ret.prototype = streamifyAll(this.wrapCallback, arg.prototype, suffix);
     }
     return ret;
-};
+});
 
 /**
  * Add two values. Can be partially applied.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1147,7 +1147,7 @@ addMethod('consume', function (f) {
     gen.pullCb = pullCb;
     gen.source = source;
 
-    consumer = this._consumer = new this.constructor(gen);
+    consumer = this._consumer = this.create(gen);
 
     consumer.id = 'consume:' + consumer.id;
     consumer.onDestroy(this.destroy.bind(this));
@@ -1301,7 +1301,7 @@ addMethod('fork', function () {
  */
 
 addMethod('observe', function () {
-    var s = new this.constructor();
+    var s = this.create();
     s.id = 'observe:' + s.id;
 
     s.onDestroy(this._removeObserver.bind(this, s));
@@ -2815,7 +2815,7 @@ addToplevelMethod('pipeline', function (/*through...*/) {
 addMethod('sequence', function () {
     var original = this;
     var curr = this;
-    return new this.constructor(function (push, next) {
+    return this.create(function (push, next) {
         curr.pull(function (err, x) {
             if (err) {
                 push(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1149,7 +1149,7 @@ Stream.prototype.consume = function (f) {
     gen.pullCb = pullCb;
     gen.source = source;
 
-    consumer = this._consumer = new Stream(gen);
+    consumer = this._consumer = new this.constructor(gen);
 
     consumer.id = 'consume:' + consumer.id;
     consumer.onDestroy(this.destroy.bind(this));
@@ -1304,7 +1304,7 @@ Stream.prototype.fork = function () {
  */
 
 Stream.prototype.observe = function () {
-    var s = new Stream();
+    var s = new this.constructor();
     s.id = 'observe:' + s.id;
 
     s.onDestroy(this._removeObserver.bind(this, s));

--- a/lib/index.js
+++ b/lib/index.js
@@ -706,28 +706,27 @@ function Stream(generator) {
 }
 inherits(Stream, EventEmitter);
 
-Stream._addMethod = function(name, f, options) {
-    this.prototype[name] = f;
+function _addMethod(obj, name, f, options) {
+    obj.prototype[name] = f;
     var n = f.length;
-    var that = this;
     if (options && options.expose) {
-        this[name] = _.ncurry(n + 1, function () {
+        obj[name] = _.ncurry(n + 1, function () {
             var args = slice.call(arguments);
-            var s = that(args.pop());
+            var s = obj(args.pop());
             return f.apply(s, args);
         });
     }
-};
+}
 
-Stream._addMethods = function(methods) {
+function _addMethods(obj, methods) {
     for (var p in methods) {
         if (hasOwn.call(methods, p)) {
-            this._addMethod(p, methods[p], {expose: true});
+            _addMethod(obj, p, methods[p], {expose: true});
         }
     }
 
     return this;
-};
+}
 
 Stream.use = function(methods) {
     var Sup = this;
@@ -745,7 +744,7 @@ Stream.use = function(methods) {
             Sub[p] = Sup[p];
         }
     }
-    Sub._addMethods(methods || {});
+    _addMethods(Sub, methods || {});
 
     return Sub;
 };
@@ -865,7 +864,7 @@ Stream.prototype._onEnd = function _onEnd() {
  * xs.pause();
  */
 
-Stream._addMethod('pause', function () {
+_addMethod(Stream, 'pause', function () {
     //console.log(['pause', this.id]);
     this.paused = true;
 });
@@ -899,7 +898,7 @@ Stream.prototype._emitNext = function (num) {
  * xs.resume();
  */
 
-Stream._addMethod('resume', function () {
+_addMethod(Stream, 'resume', function () {
     // console.log(this.id, 'resume', this.paused);
     if (!this.paused ||
             (this._consumer && this._consumer.paused) ||
@@ -945,7 +944,7 @@ Stream._addMethod('resume', function () {
  * mystream.end();
  */
 
-Stream._addMethod('end', function () {
+_addMethod(Stream, 'end', function () {
     this.write(nil);
 });
 
@@ -972,7 +971,7 @@ Stream._addMethod('end', function () {
  * source.pipe(through).pipe(dest);
  */
 
-Stream._addMethod('pipe', function (dest) {
+_addMethod(Stream, 'pipe', function (dest) {
     var self = this;
 
     // stdout and stderr are special case writables that cannot be closed
@@ -1032,7 +1031,7 @@ Stream._addMethod('pipe', function (dest) {
  * @api public
  */
 
-Stream._addMethod('destroy', function () {
+_addMethod(Stream, 'destroy', function () {
     // Already destroyed.
     if (this.ended) {
         return;
@@ -1151,7 +1150,7 @@ Stream.prototype._removeObserver = function (s) {
  * };
  */
 
-Stream._addMethod('consume', function (f) {
+_addMethod(Stream, 'consume', function (f) {
     var source = this,
         consumer;
 
@@ -1223,7 +1222,7 @@ Stream._addMethod('consume', function (f) {
  * });
  */
 
-Stream._addMethod('pull', function (f) {
+_addMethod(Stream, 'pull', function (f) {
     // console.log(this.id, 'pull', this._outgoing.toArray(), this.paused);
     if (this._request) {
         f(new Error('Cannot service a second pull() request while one is in progress.'));
@@ -1267,7 +1266,7 @@ Stream._addMethod('pull', function (f) {
  * xs2.write(1); // This call is illegal.
  */
 
-Stream._addMethod('write', function (x) {
+_addMethod(Stream, 'write', function (x) {
     // console.log(this.id, 'write', x, this.paused);
     this._writeOutgoing(x);
     return !this.paused;
@@ -1294,7 +1293,7 @@ Stream._addMethod('write', function (x) {
  * zs.resume();
  */
 
-Stream._addMethod('fork', function () {
+_addMethod(Stream, 'fork', function () {
     if (this._requests) {
         throw new Error('Cannot fork a stream with an outstanding pull() request.');
     }
@@ -1332,7 +1331,7 @@ Stream._addMethod('fork', function () {
  * ys.resume();
  */
 
-Stream._addMethod('observe', function () {
+_addMethod(Stream, 'observe', function () {
     var s = new this.constructor();
     s.id = 'observe:' + s.id;
 
@@ -1367,7 +1366,7 @@ Stream._addMethod('observe', function () {
  * });
  */
 
-Stream._addMethod('errors', function (f) {
+_addMethod(Stream, 'errors', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             f(err, push);
@@ -1398,7 +1397,7 @@ Stream._addMethod('errors', function (f) {
  * });
  */
 
-Stream._addMethod('stopOnError', function (f) {
+_addMethod(Stream, 'stopOnError', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             f(err, push);
@@ -1432,7 +1431,7 @@ Stream._addMethod('stopOnError', function (f) {
  * });
  */
 
-Stream._addMethod('each', function (f) {
+_addMethod(Stream, 'each', function (f) {
     var self = this;
     var s = this.consume(function (err, x, push, next) {
         if (err) {
@@ -1472,7 +1471,7 @@ Stream._addMethod('each', function (f) {
  * });
  */
 
-Stream._addMethod('apply', function (f) {
+_addMethod(Stream, 'apply', function (f) {
     return this.toArray(function (args) {
         f.apply(null, args);
     });
@@ -1496,7 +1495,7 @@ Stream._addMethod('apply', function (f) {
  * });
  */
 
-Stream._addMethod('toArray', function (f) {
+_addMethod(Stream, 'toArray', function (f) {
     var self = this;
     return this.collect().pull(function (err, x) {
         if (err) {
@@ -1529,7 +1528,7 @@ Stream._addMethod('toArray', function (f) {
  * });
  */
 
-Stream._addMethod('done', function (f) {
+_addMethod(Stream, 'done', function (f) {
     if (this.ended) {
         f();
         return null;
@@ -1591,7 +1590,7 @@ Stream.prototype.onDestroy = function onDestroy(f) {
  * _([1, 2, 3]).map('hi')  // => 'hi', 'hi', 'hi'
  */
 
-Stream._addMethod('map', function (f) {
+_addMethod(Stream, 'map', function (f) {
     if (!_.isFunction(f)) {
         var val = f;
         f = function () {
@@ -1642,7 +1641,7 @@ Stream._addMethod('map', function (f) {
  * // => 1, 2, 3
  */
 
-Stream._addMethod('doto', function (f) {
+_addMethod(Stream, 'doto', function (f) {
     return this.map(function (x) {
         f(x);
         return x;
@@ -1683,7 +1682,7 @@ _.tap = _.doto;
  * // after 200ms => 1, 2, 3, 4, 5
  */
 
-Stream._addMethod('ratelimit', function (num, ms) {
+_addMethod(Stream, 'ratelimit', function (num, ms) {
     if (num < 1) {
         throw new Error('Invalid number of operations per ms: ' + num);
     }
@@ -1727,7 +1726,7 @@ Stream._addMethod('ratelimit', function (num, ms) {
  * filenames.flatMap(readFile)
  */
 
-Stream._addMethod('flatMap', function (f) {
+_addMethod(Stream, 'flatMap', function (f) {
     return this.map(f).sequence();
 }, {expose: true});
 
@@ -1752,7 +1751,7 @@ Stream._addMethod('flatMap', function (f) {
  * });
  */
 
-Stream._addMethod('pluck', function (prop) {
+_addMethod(Stream, 'pluck', function (prop) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             push(err);
@@ -1822,7 +1821,7 @@ var objectOnly = _.curry(function(strategy, x) {
  *  });
  */
 
-Stream._addMethod('pickBy', function (f) {
+_addMethod(Stream, 'pickBy', function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
 
@@ -1886,7 +1885,7 @@ Stream._addMethod('pickBy', function (f) {
  *      ]
  * });*/
 
-Stream._addMethod('pick', function (properties) {
+_addMethod(Stream, 'pick', function (properties) {
     return this.map(objectOnly(function(x) {
         var out = {};
         for (var i = 0, length = properties.length; i < length; i++) {
@@ -1913,7 +1912,7 @@ Stream._addMethod('pick', function (properties) {
  * });
  */
 
-Stream._addMethod('filter', function (f) {
+_addMethod(Stream, 'filter', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             push(err);
@@ -1959,7 +1958,7 @@ Stream._addMethod('filter', function (f) {
  * filenames.flatFilter(checkExists)
  */
 
-Stream._addMethod('flatFilter', function (f) {
+_addMethod(Stream, 'flatFilter', function (f) {
     return this.flatMap(function (x) {
         return f(x).take(1).otherwise(errorStream())
         .flatMap(function (bool) {
@@ -1989,7 +1988,7 @@ Stream._addMethod('flatFilter', function (f) {
  * });
  */
 
-Stream._addMethod('reject', function (f) {
+_addMethod(Stream, 'reject', function (f) {
     return this.filter(_.compose(_.not, f));
 }, {expose: true});
 
@@ -2023,7 +2022,7 @@ Stream._addMethod('reject', function (f) {
  * // => {type: 'blogpost', title: 'foo'}
  */
 
-Stream._addMethod('find', function (f) {
+_addMethod(Stream, 'find', function (f) {
     return this.filter(f).take(1);
 }, {expose: true});
 
@@ -2053,7 +2052,7 @@ Stream._addMethod('find', function (f) {
  * // => {type: 'blogpost', title: 'foo'}
  */
 
-Stream._addMethod('findWhere', function (props) {
+_addMethod(Stream, 'findWhere', function (props) {
     return this.where(props).take(1);
 }, {expose: true});
 
@@ -2086,7 +2085,7 @@ Stream._addMethod('findWhere', function (props) {
  *
  */
 
-Stream._addMethod('group', function (f) {
+_addMethod(Stream, 'group', function (f) {
     var lambda = _.isString(f) ? _.get(f) : f;
     return this.reduce(function (m, o) {
         var key = lambda(o);
@@ -2108,7 +2107,7 @@ Stream._addMethod('group', function (f) {
  * // => 1, 3, 6
  */
 
-Stream._addMethod('compact', function () {
+_addMethod(Stream, 'compact', function () {
     return this.filter(function (x) {
         return x;
     });
@@ -2142,7 +2141,7 @@ Stream._addMethod('compact', function () {
  * // => {type: 'blogpost', title: 'bar'}
  */
 
-Stream._addMethod('where', function (props) {
+_addMethod(Stream, 'where', function (props) {
     return this.filter(function (x) {
         for (var k in props) {
             if (x[k] !== props[k]) {
@@ -2178,7 +2177,7 @@ Stream._addMethod('where', function (props) {
  *
  */
 
-Stream._addMethod('uniqBy', function (compare) {
+_addMethod(Stream, 'uniqBy', function (compare) {
     var uniques = [];
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -2232,7 +2231,7 @@ Stream._addMethod('uniqBy', function (compare) {
  * // => 'yellow'
  */
 
-Stream._addMethod('uniq', function () {
+_addMethod(Stream, 'uniq', function () {
     return this.uniqBy(function (a, b) {
         return a === b;
     });
@@ -2267,7 +2266,7 @@ Stream._addMethod('uniq', function () {
  * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
  */
 
-Stream._addMethod('zipAll', function () {
+_addMethod(Stream, 'zipAll', function () {
     var returned = 0;
     var z = [];
     var finished = false;
@@ -2329,7 +2328,7 @@ Stream._addMethod('zipAll', function () {
  * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
  */
 
-Stream._addMethod('zipEach', function (ys) {
+_addMethod(Stream, 'zipEach', function (ys) {
     return _([this]).concat(_(ys).map(_)).zipAll0();
 }, {expose: true});
 
@@ -2345,7 +2344,7 @@ Stream._addMethod('zipEach', function (ys) {
  * _(['a', 'b', 'c']).zip([1, 2, 3])  // => ['a', 1], ['b', 2], ['c', 3]
  */
 
-Stream._addMethod('zip', function (ys) {
+_addMethod(Stream, 'zip', function (ys) {
     return _([this, _(ys)]).zipAll();
 }, {expose: true});
 
@@ -2361,7 +2360,7 @@ Stream._addMethod('zip', function (ys) {
  * _([1, 2, 3, 4, 5]).batch(2)  // => [1, 2], [3, 4], [5]
  */
 
-Stream._addMethod('batch', function (n) {
+_addMethod(Stream, 'batch', function (n) {
     return this.batchWithTimeOrCount(-1, n);
 }, {expose: true});
 
@@ -2386,7 +2385,7 @@ Stream._addMethod('batch', function (n) {
  * // => [1, 2], [3], [4]
  */
 
-Stream._addMethod('batchWithTimeOrCount', function (ms, n) {
+_addMethod(Stream, 'batchWithTimeOrCount', function (ms, n) {
     var batched = [],
         timeout;
 
@@ -2439,7 +2438,7 @@ Stream._addMethod('batchWithTimeOrCount', function (ms, n) {
  * _(['foo']).intersperse('bar')  // => foo
  */
 
-Stream._addMethod('intersperse', function (separator) {
+_addMethod(Stream, 'intersperse', function (separator) {
     var started = false;
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -2478,7 +2477,7 @@ Stream._addMethod('intersperse', function (separator) {
  * _(['foo']).splitBy('bar')  // => foo
  */
 
-Stream._addMethod('splitBy', function (sep) {
+_addMethod(Stream, 'splitBy', function (sep) {
     var decoder = new Decoder();
     var buffer = false;
 
@@ -2523,7 +2522,7 @@ Stream._addMethod('splitBy', function (sep) {
  * _(['a\r\nb\nc']]).split()  // => a, b, c
  */
 
-Stream._addMethod('split', function () {
+_addMethod(Stream, 'split', function () {
     return this.splitBy(/\r?\n/);
 }, {expose: true});
 
@@ -2543,7 +2542,7 @@ Stream._addMethod('split', function () {
  * _([1, 2, 3, 4]).slice(1, 3) // => 2, 3
  */
 
-Stream._addMethod('slice', function(start, end) {
+_addMethod(Stream, 'slice', function(start, end) {
     var index = 0;
     start = typeof start != 'number' || start < 0 ? 0 : start;
     end = typeof end != 'number' ? Infinity : end;
@@ -2586,7 +2585,7 @@ Stream._addMethod('slice', function(start, end) {
  * _([1, 2, 3, 4]).take(2) // => 1, 2
  */
 
-Stream._addMethod('take', function (n) {
+_addMethod(Stream, 'take', function (n) {
     var s = this.slice(0, n);
     s.id = 'take:' + s.id;
     return s;
@@ -2606,7 +2605,7 @@ Stream._addMethod('take', function (n) {
  * _([1, 2, 3, 4]).drop(2) // => 3, 4
  */
 
-Stream._addMethod('drop', function (n) {
+_addMethod(Stream, 'drop', function (n) {
     return this.slice(n, Infinity);
 }, {expose: true});
 
@@ -2621,7 +2620,7 @@ Stream._addMethod('drop', function (n) {
  * _([1, 2, 3, 4]).head() // => 1
  */
 
-Stream._addMethod('head', function () {
+_addMethod(Stream, 'head', function () {
     return this.take(1);
 }, {expose: true});
 
@@ -2636,7 +2635,7 @@ Stream._addMethod('head', function () {
  * _([1, 2, 3, 4]).last()  // => 4
  */
 
-Stream._addMethod('last', function () {
+_addMethod(Stream, 'last', function () {
     var nothing = {};
     var prev = nothing;
     return this.consume(function (err, x, push, next) {
@@ -2675,7 +2674,7 @@ Stream._addMethod('last', function () {
  * //=> [4, 3, 2, 1]
  */
 
-Stream._addMethod('sortBy', function (f) {
+_addMethod(Stream, 'sortBy', function (f) {
     return this.collect().invoke('sort', [f]).sequence();
 }, {expose: true});
 
@@ -2692,7 +2691,7 @@ Stream._addMethod('sortBy', function (f) {
  * // => ['b', 'g', 'r', 'z']
  */
 
-Stream._addMethod('sort', function () {
+_addMethod(Stream, 'sort', function () {
     return this.sortBy();
 }, {expose: true});
 
@@ -2732,7 +2731,7 @@ Stream._addMethod('sort', function () {
  * });
  */
 
-Stream._addMethod('through', function (target) {
+_addMethod(Stream, 'through', function (target) {
     var output;
 
     if (_.isFunction(target)) {
@@ -2825,7 +2824,7 @@ _.pipeline = function (/*through...*/) {
  * filenames.map(readFile).sequence()
  */
 
-Stream._addMethod('sequence', function () {
+_addMethod(Stream, 'sequence', function () {
     var original = this;
     var curr = this;
     return _(function (push, next) {
@@ -2924,7 +2923,7 @@ _.series = _.sequence;
  * nums.flatten();  // => 1, 2, 3, 4, 5, 6
  */
 
-Stream._addMethod('flatten', function () {
+_addMethod(Stream, 'flatten', function () {
     var curr = this;
     var stack = [];
     return _(function (push, next) {
@@ -2976,7 +2975,7 @@ Stream._addMethod('flatten', function () {
  * filenames.map(readFile).parallel(10);
  */
 
-Stream._addMethod('parallel', function (n) {
+_addMethod(Stream, 'parallel', function (n) {
     var source = this;
     var running = [];
     var ended = false;
@@ -3080,7 +3079,7 @@ Stream._addMethod('parallel', function (n) {
  * _.otherwise(_(['foo']), _([]))         // => 'foo'
  */
 
-Stream._addMethod('otherwise', function (ys) {
+_addMethod(Stream, 'otherwise', function (ys) {
     var xs = this;
     return xs.consume(function (err, x, push, next) {
         if (err) {
@@ -3117,7 +3116,7 @@ Stream._addMethod('otherwise', function (ys) {
  * _([1, 2, 3]).append(4)  // => 1, 2, 3, 4
  */
 
-Stream._addMethod('append', function (y) {
+_addMethod(Stream, 'append', function (y) {
     return this.consume(function (err, x, push, next) {
         if (x === nil) {
             push(null, y);
@@ -3153,7 +3152,7 @@ Stream._addMethod('append', function (y) {
  * _([1, 2, 3, 4]).reduce(add, 0)  // => 10
  */
 
-Stream._addMethod('reduce', function (f, z) {
+_addMethod(Stream, 'reduce', function (f, z) {
     // This can't be implemented with scan(), because we don't know if the
     // errors that we see from the scan were thrown by the iterator or just
     // passed through from the source stream.
@@ -3194,7 +3193,7 @@ Stream._addMethod('reduce', function (f, z) {
  * _([1, 2, 3, 4]).reduce1(add)  // => 10
  */
 
-Stream._addMethod('reduce1', function (f) {
+_addMethod(Stream, 'reduce1', function (f) {
     var self = this;
     return _(function (push, next) {
         self.pull(function (err, x) {
@@ -3227,7 +3226,7 @@ Stream._addMethod('reduce1', function (f) {
  * });
  */
 
-Stream._addMethod('collect', function () {
+_addMethod(Stream, 'collect', function () {
     var xs = [];
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -3263,7 +3262,7 @@ Stream._addMethod('collect', function () {
  * _([1, 2, 3, 4]).scan(add, 0)  // => 0, 1, 3, 6, 10
  */
 
-Stream._addMethod('scan', function (f, z) {
+_addMethod(Stream, 'scan', function (f, z) {
     var self = this;
     return _([z]).concat(
         self.consume(function (err, x, push, next) {
@@ -3304,7 +3303,7 @@ Stream._addMethod('scan', function (f, z) {
  * _([1, 2, 3, 4]).scan1(add)  // => 1, 3, 6, 10
  */
 
-Stream._addMethod('scan1', function (f) {
+_addMethod(Stream, 'scan1', function (f) {
     var self = this;
     return _(function (push, next) {
         self.pull(function (err, x) {
@@ -3368,7 +3367,7 @@ HighlandTransform.prototype['@@transducer/step'] = function (push, input) {
  * // => [2, 3, 4, 5]
  */
 
-Stream._addMethod('transduce', function transduce(xf) {
+_addMethod(Stream, 'transduce', function transduce(xf) {
     var transform = null,
         memo = null;
 
@@ -3444,7 +3443,7 @@ Stream._addMethod('transduce', function transduce(xf) {
  * _.concat([3, 4], [1, 2])  // => 1, 2, 3, 4
  */
 
-Stream._addMethod('concat', function (ys) {
+_addMethod(Stream, 'concat', function (ys) {
     ys = _(ys);
     return this.consume(function (err, x, push, next) {
         if (x === nil) {
@@ -3479,7 +3478,7 @@ Stream._addMethod('concat', function (ys) {
  * // => contents of foo.txt, bar.txt and baz.txt in the order they were read
  */
 
-Stream._addMethod('merge', function () {
+_addMethod(Stream, 'merge', function () {
     var self = this;
     var srcs = [];
 
@@ -3601,7 +3600,7 @@ Stream._addMethod('merge', function () {
  * filenames.map(readFile).sequence().invoke('toString', ['utf8']);
  */
 
-Stream._addMethod('invoke', function (method, args) {
+_addMethod(Stream, 'invoke', function (method, args) {
     return this.map(function (x) {
         return x[method].apply(x, args);
     });
@@ -3656,7 +3655,7 @@ Stream._addMethod('invoke', function (method, args) {
  *
  */
 
-Stream._addMethod('nfcall', function (args) {
+_addMethod(Stream, 'nfcall', function (args) {
     return this.map(function (x) {
         return _.wrapCallback(x).apply(x, args);
     });
@@ -3675,7 +3674,7 @@ Stream._addMethod('nfcall', function (args) {
  * _('mousemove', document).throttle(1000);
  */
 
-Stream._addMethod('throttle', function (ms) {
+_addMethod(Stream, 'throttle', function (ms) {
     var last = 0 - ms;
     return this.consume(function (err, x, push, next) {
         var now = new Date().getTime();
@@ -3712,7 +3711,7 @@ Stream._addMethod('throttle', function (ms) {
  * $('keyup', textbox).debounce(1000);
  */
 
-Stream._addMethod('debounce', function (ms) {
+_addMethod(Stream, 'debounce', function (ms) {
     var t = null;
     var nothing = {};
     var last = nothing;
@@ -3759,7 +3758,7 @@ Stream._addMethod('debounce', function (ms) {
  * mousePosition.latest().map(slowThing)
  */
 
-Stream._addMethod('latest', function () {
+_addMethod(Stream, 'latest', function () {
     var nothing = {},
         latest = nothing,
         errors = [],

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,14 @@ function __(Stream) {
             s = new Stream();
         }
         else if (_.isStream(xs)) {
-            s = xs;
+            if (!(xs instanceof Stream)) { // different subclass or version
+                var ret = new Stream();
+                xs.on('error', ret.write.bind(ret));
+                s = xs.pipe(ret);
+            }
+            else {
+                s = xs;
+            }
         }
         else if (_.isArray(xs)) {
             s = new Stream();
@@ -639,11 +646,15 @@ function _addMethod(proto, topLevel) {
         proto[name] = f;
         var n = f.length;
         if (options && options.expose) {
-            topLevel[name] = _.ncurry(n + 1, function () {
-                var args = slice.call(arguments);
-                var s = topLevel(args.pop());
-                return f.apply(s, args);
-            });
+            function relevel(coerce) {
+                return _.ncurry(n + 1, function () {
+                    var args = slice.call(arguments);
+                    var s = coerce(args.pop());
+                    return f.apply(s, args);
+                });
+            }
+            topLevel[name] = relevel(topLevel);
+            topLevel[name]._relevel = relevel;
         }
     };
 }
@@ -670,7 +681,8 @@ function use(Super, originalTopLevel) {
         }
         for (var p in originalTopLevel) {
             if (hasOwn.call(originalTopLevel, p)) {
-                topLevel[p] = originalTopLevel[p];
+                var fn = originalTopLevel[p];
+                topLevel[p] = (typeof fn._relevel === 'function') ? fn._relevel(topLevel) : fn;
             }
         }
         _addMethods(Sub.prototype, topLevel, methods || {});

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,95 +116,98 @@ else if (typeof window !== 'undefined') {
  */
 
 /*eslint-disable no-multi-spaces */
-var _ = exports = module.exports = function (/*optional*/xs, /*optional*/ee, /*optional*/ mappingHint) {
-    /*eslint-enable no-multi-spaces */
-    var s = null;
-    if (_.isUndefined(xs)) {
-        // nothing else to do
-        s = new Stream();
-    }
-    else if (_.isStream(xs)) {
-        s = xs;
-    }
-    else if (_.isArray(xs)) {
-        s = new Stream();
-        s._outgoing.enqueueAll(xs);
-        s._outgoing.enqueue(_.nil);
-    }
-    else if (_.isFunction(xs)) {
-        s = new Stream(xs);
-    }
-    else if (_.isObject(xs)) {
-        // check to see if we have a readable stream
-        if (_.isFunction(xs.on) && _.isFunction(xs.pipe)) {
+var _ = exports = module.exports = __(Stream);
+function __(Stream) {
+    return function(/*optional*/xs, /*optional*/ee, /*optional*/ mappingHint) {
+        /*eslint-enable no-multi-spaces */
+        var s = null;
+        if (_.isUndefined(xs)) {
+            // nothing else to do
             s = new Stream();
-            // write any errors into the stream
-            xs.on('error', s._push_fn);
-            xs.on('end', s.write.bind(s, _.nil));
-            // assume it's a pipeable stream as a source
-            xs.pipe(s);
         }
-        else if (_.isFunction(xs.then)) {
-            // probably a promise
-            s = promiseStream(xs);
+        else if (_.isStream(xs)) {
+            s = xs;
         }
-        // must check iterators and iterables in this order
-        // because generators are both iterators and iterables:
-        // their Symbol.iterator method returns the `this` object
-        // and an infinite loop would result otherwise
-        else if (_.isFunction(xs.next)) {
-            //probably an iterator
-            return iteratorStream(xs);
+        else if (_.isArray(xs)) {
+            s = new Stream();
+            s._outgoing.enqueueAll(xs);
+            s._outgoing.enqueue(_.nil);
         }
-        else if (!_.isUndefined(_global.Symbol) && xs[_global.Symbol.iterator]) {
-            //probably an iterable
-            return iteratorStream(xs[_global.Symbol.iterator]());
+        else if (_.isFunction(xs)) {
+            s = new Stream(xs);
+        }
+        else if (_.isObject(xs)) {
+            // check to see if we have a readable stream
+            if (_.isFunction(xs.on) && _.isFunction(xs.pipe)) {
+                s = new Stream();
+                // write any errors into the stream
+                xs.on('error', s._push_fn);
+                xs.on('end', s.write.bind(s, _.nil));
+                // assume it's a pipeable stream as a source
+                xs.pipe(s);
+            }
+            else if (_.isFunction(xs.then)) {
+                // probably a promise
+                s = promiseStream(Stream, xs);
+            }
+            // must check iterators and iterables in this order
+            // because generators are both iterators and iterables:
+            // their Symbol.iterator method returns the `this` object
+            // and an infinite loop would result otherwise
+            else if (_.isFunction(xs.next)) {
+                //probably an iterator
+                return iteratorStream(Stream, xs);
+            }
+            else if (!_.isUndefined(_global.Symbol) && xs[_global.Symbol.iterator]) {
+                //probably an iterable
+                return iteratorStream(Stream, xs[_global.Symbol.iterator]());
+            }
+            else {
+                throw new Error(
+                    'Object was not a stream, promise, iterator or iterable: ' + (typeof xs)
+                );
+            }
+        }
+        else if (_.isString(xs)) {
+            var mappingHintType = (typeof mappingHint);
+            var mapper;
+
+            if (mappingHintType === 'function') {
+                mapper = mappingHint;
+            }
+            else if (mappingHintType === 'number') {
+                mapper = function () {
+                    return slice.call(arguments, 0, mappingHint);
+                };
+            }
+            else if (_.isArray(mappingHint)) {
+                mapper = function () {
+                    var args = arguments;
+                    return mappingHint.reduce(function (ctx, hint, idx) {
+                        ctx[hint] = args[idx];
+                        return ctx;
+                    }, {});
+                };
+            }
+            else {
+                mapper = function (x) { return x; };
+            }
+
+            s = new Stream();
+            ee.on(xs, function () {
+                var ctx = mapper.apply(this, arguments);
+                s.write(ctx);
+            });
         }
         else {
             throw new Error(
-                'Object was not a stream, promise, iterator or iterable: ' + (typeof xs)
+                'Unexpected argument type to Stream constructor: ' + (typeof xs)
             );
         }
-    }
-    else if (_.isString(xs)) {
-        var mappingHintType = (typeof mappingHint);
-        var mapper;
 
-        if (mappingHintType === 'function') {
-            mapper = mappingHint;
-        }
-        else if (mappingHintType === 'number') {
-            mapper = function () {
-                return slice.call(arguments, 0, mappingHint);
-            };
-        }
-        else if (_.isArray(mappingHint)) {
-            mapper = function () {
-                var args = arguments;
-                return mappingHint.reduce(function (ctx, hint, idx) {
-                    ctx[hint] = args[idx];
-                    return ctx;
-                }, {});
-            };
-        }
-        else {
-            mapper = function (x) { return x; };
-        }
-
-        s = new Stream();
-        ee.on(xs, function () {
-            var ctx = mapper.apply(this, arguments);
-            s.write(ctx);
-        });
-    }
-    else {
-        throw new Error(
-            'Unexpected argument type to Stream constructor: ' + (typeof xs)
-        );
-    }
-
-    return s;
-};
+        return s;
+    };
+}
 /*eslint-enable no-use-before-define */
 
 // ES5 detected value, used for switch between ES5 and ES3 code
@@ -484,8 +487,8 @@ function newDelegateGenerator(pull) {
     };
 }
 
-function promiseStream(promise) {
-    return _(function (push) {
+function promiseStream(Stream, promise) {
+    return new Stream(function (push) {
         promise.then(function (value) {
                 push(null, value);
                 return push(null, nil);
@@ -497,8 +500,8 @@ function promiseStream(promise) {
     });
 }
 
-function iteratorStream(it) {
-    return _(function (push, next) {
+function iteratorStream(Stream, it) {
+    return new Stream(function (push, next) {
         var iterElem, iterErr;
         try {
             iterElem = it.next();
@@ -585,7 +588,7 @@ function Stream(generator) {
 
         self._generator_requested = true;
         if (xs) {
-            xs = _(xs);
+            xs = self.create(xs);
             var pull = newPullFunction(xs);
             self._generator = newDelegateGenerator(pull);
         }
@@ -631,48 +634,57 @@ function Stream(generator) {
 }
 inherits(Stream, EventEmitter);
 
-function _addMethod(obj, name, f, options) {
-    obj.prototype[name] = f;
-    var n = f.length;
-    if (options && options.expose) {
-        obj[name] = _.ncurry(n + 1, function () {
-            var args = slice.call(arguments);
-            var s = obj(args.pop());
-            return f.apply(s, args);
-        });
-    }
+function _addMethod(proto, topLevel) {
+    return function(name, f, options) {
+        proto[name] = f;
+        var n = f.length;
+        if (options && options.expose) {
+            topLevel[name] = _.ncurry(n + 1, function () {
+                var args = slice.call(arguments);
+                var s = topLevel(args.pop());
+                return f.apply(s, args);
+            });
+        }
+    };
 }
 
-function _addMethods(obj, methods) {
+var addMethod = _addMethod(Stream.prototype, _);
+
+function _addMethods(proto, topLevel, methods) {
     for (var p in methods) {
         if (hasOwn.call(methods, p)) {
-            _addMethod(obj, p, methods[p], {expose: true});
+            _addMethod(proto, topLevel)(p, methods[p], {expose: true});
         }
     }
-
-    return this;
 }
 
-Stream.use = function(methods) {
-    var Sup = this;
-    function Sub(xs, ee, mappingHint) {
-        if (!(this instanceof Sub)) {
-            return new Sub(xs, ee, mappingHint);
+function use(Super, originalTopLevel) {
+    return function(methods) {
+        function Sub() {
+            Stream.apply(this, arguments);
         }
+        inherits(Sub, Super);
 
-        // Stream.apply is something else...
-        Function.prototype.apply.call(Stream, this, arguments);
-    }
-    inherits(Sub, Sup);
-    for (var p in Sup) {
-        if (hasOwn.call(Sup, p)) {
-            Sub[p] = Sup[p];
+        function topLevel() {
+            return __(Sub).apply(null, arguments);
         }
-    }
-    _addMethods(Sub, methods || {});
+        for (var p in originalTopLevel) {
+            if (hasOwn.call(originalTopLevel, p)) {
+                topLevel[p] = originalTopLevel[p];
+            }
+        }
+        _addMethods(Sub.prototype, topLevel, methods || {});
+        topLevel.use = use(Sub, topLevel);
 
-    return Sub;
-};
+        return topLevel;
+    };
+}
+
+_.use = use(Stream, _);
+
+addMethod('create', function() {
+    return __(this.constructor).apply(null, arguments);
+});
 
 /**
  * Used as an Error marker when writing to a Stream's incoming buffer
@@ -789,7 +801,7 @@ Stream.prototype._onEnd = function _onEnd() {
  * xs.pause();
  */
 
-_addMethod(Stream, 'pause', function () {
+addMethod('pause', function () {
     //console.log(['pause', this.id]);
     this.paused = true;
 });
@@ -823,7 +835,7 @@ Stream.prototype._emitNext = function (num) {
  * xs.resume();
  */
 
-_addMethod(Stream, 'resume', function () {
+addMethod('resume', function () {
     // console.log(this.id, 'resume', this.paused);
     if (!this.paused ||
             (this._consumer && this._consumer.paused) ||
@@ -869,7 +881,7 @@ _addMethod(Stream, 'resume', function () {
  * mystream.end();
  */
 
-_addMethod(Stream, 'end', function () {
+addMethod('end', function () {
     this.write(nil);
 });
 
@@ -896,7 +908,7 @@ _addMethod(Stream, 'end', function () {
  * source.pipe(through).pipe(dest);
  */
 
-_addMethod(Stream, 'pipe', function (dest) {
+addMethod('pipe', function (dest) {
     var self = this;
 
     // stdout and stderr are special case writables that cannot be closed
@@ -956,7 +968,7 @@ _addMethod(Stream, 'pipe', function (dest) {
  * @api public
  */
 
-_addMethod(Stream, 'destroy', function () {
+addMethod('destroy', function () {
     // Already destroyed.
     if (this.ended) {
         return;
@@ -1075,7 +1087,7 @@ Stream.prototype._removeObserver = function (s) {
  * };
  */
 
-_addMethod(Stream, 'consume', function (f) {
+addMethod('consume', function (f) {
     var source = this,
         consumer;
 
@@ -1147,7 +1159,7 @@ _addMethod(Stream, 'consume', function (f) {
  * });
  */
 
-_addMethod(Stream, 'pull', function (f) {
+addMethod('pull', function (f) {
     // console.log(this.id, 'pull', this._outgoing.toArray(), this.paused);
     if (this._request) {
         f(new Error('Cannot service a second pull() request while one is in progress.'));
@@ -1191,7 +1203,7 @@ _addMethod(Stream, 'pull', function (f) {
  * xs2.write(1); // This call is illegal.
  */
 
-_addMethod(Stream, 'write', function (x) {
+addMethod('write', function (x) {
     // console.log(this.id, 'write', x, this.paused);
     this._writeOutgoing(x);
     return !this.paused;
@@ -1218,7 +1230,7 @@ _addMethod(Stream, 'write', function (x) {
  * zs.resume();
  */
 
-_addMethod(Stream, 'fork', function () {
+addMethod('fork', function () {
     if (this._requests) {
         throw new Error('Cannot fork a stream with an outstanding pull() request.');
     }
@@ -1256,7 +1268,7 @@ _addMethod(Stream, 'fork', function () {
  * ys.resume();
  */
 
-_addMethod(Stream, 'observe', function () {
+addMethod('observe', function () {
     var s = new this.constructor();
     s.id = 'observe:' + s.id;
 
@@ -1291,7 +1303,7 @@ _addMethod(Stream, 'observe', function () {
  * });
  */
 
-_addMethod(Stream, 'errors', function (f) {
+addMethod('errors', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             f(err, push);
@@ -1322,7 +1334,7 @@ _addMethod(Stream, 'errors', function (f) {
  * });
  */
 
-_addMethod(Stream, 'stopOnError', function (f) {
+addMethod('stopOnError', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             f(err, push);
@@ -1356,7 +1368,7 @@ _addMethod(Stream, 'stopOnError', function (f) {
  * });
  */
 
-_addMethod(Stream, 'each', function (f) {
+addMethod('each', function (f) {
     var self = this;
     var s = this.consume(function (err, x, push, next) {
         if (err) {
@@ -1396,7 +1408,7 @@ _addMethod(Stream, 'each', function (f) {
  * });
  */
 
-_addMethod(Stream, 'apply', function (f) {
+addMethod('apply', function (f) {
     return this.toArray(function (args) {
         f.apply(null, args);
     });
@@ -1420,7 +1432,7 @@ _addMethod(Stream, 'apply', function (f) {
  * });
  */
 
-_addMethod(Stream, 'toArray', function (f) {
+addMethod('toArray', function (f) {
     var self = this;
     return this.collect().pull(function (err, x) {
         if (err) {
@@ -1453,7 +1465,7 @@ _addMethod(Stream, 'toArray', function (f) {
  * });
  */
 
-_addMethod(Stream, 'done', function (f) {
+addMethod('done', function (f) {
     if (this.ended) {
         f();
         return null;
@@ -1515,7 +1527,7 @@ Stream.prototype.onDestroy = function onDestroy(f) {
  * _([1, 2, 3]).map('hi')  // => 'hi', 'hi', 'hi'
  */
 
-_addMethod(Stream, 'map', function (f) {
+addMethod('map', function (f) {
     if (!_.isFunction(f)) {
         var val = f;
         f = function () {
@@ -1566,7 +1578,7 @@ _addMethod(Stream, 'map', function (f) {
  * // => 1, 2, 3
  */
 
-_addMethod(Stream, 'doto', function (f) {
+addMethod('doto', function (f) {
     return this.map(function (x) {
         f(x);
         return x;
@@ -1607,7 +1619,7 @@ _.tap = _.doto;
  * // after 200ms => 1, 2, 3, 4, 5
  */
 
-_addMethod(Stream, 'ratelimit', function (num, ms) {
+addMethod('ratelimit', function (num, ms) {
     if (num < 1) {
         throw new Error('Invalid number of operations per ms: ' + num);
     }
@@ -1651,7 +1663,7 @@ _addMethod(Stream, 'ratelimit', function (num, ms) {
  * filenames.flatMap(readFile)
  */
 
-_addMethod(Stream, 'flatMap', function (f) {
+addMethod('flatMap', function (f) {
     return this.map(f).sequence();
 }, {expose: true});
 
@@ -1676,7 +1688,7 @@ _addMethod(Stream, 'flatMap', function (f) {
  * });
  */
 
-_addMethod(Stream, 'pluck', function (prop) {
+addMethod('pluck', function (prop) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             push(err);
@@ -1746,7 +1758,7 @@ var objectOnly = _.curry(function(strategy, x) {
  *  });
  */
 
-_addMethod(Stream, 'pickBy', function (f) {
+addMethod('pickBy', function (f) {
     return this.map(objectOnly(function (x) {
         var out = {};
 
@@ -1810,7 +1822,7 @@ _addMethod(Stream, 'pickBy', function (f) {
  *      ]
  * });*/
 
-_addMethod(Stream, 'pick', function (properties) {
+addMethod('pick', function (properties) {
     return this.map(objectOnly(function(x) {
         var out = {};
         for (var i = 0, length = properties.length; i < length; i++) {
@@ -1837,7 +1849,7 @@ _addMethod(Stream, 'pick', function (properties) {
  * });
  */
 
-_addMethod(Stream, 'filter', function (f) {
+addMethod('filter', function (f) {
     return this.consume(function (err, x, push, next) {
         if (err) {
             push(err);
@@ -1883,7 +1895,7 @@ _addMethod(Stream, 'filter', function (f) {
  * filenames.flatFilter(checkExists)
  */
 
-_addMethod(Stream, 'flatFilter', function (f) {
+addMethod('flatFilter', function (f) {
     return this.flatMap(function (x) {
         return f(x).take(1).otherwise(errorStream())
         .flatMap(function (bool) {
@@ -1913,7 +1925,7 @@ _addMethod(Stream, 'flatFilter', function (f) {
  * });
  */
 
-_addMethod(Stream, 'reject', function (f) {
+addMethod('reject', function (f) {
     return this.filter(_.compose(_.not, f));
 }, {expose: true});
 
@@ -1947,7 +1959,7 @@ _addMethod(Stream, 'reject', function (f) {
  * // => {type: 'blogpost', title: 'foo'}
  */
 
-_addMethod(Stream, 'find', function (f) {
+addMethod('find', function (f) {
     return this.filter(f).take(1);
 }, {expose: true});
 
@@ -1977,7 +1989,7 @@ _addMethod(Stream, 'find', function (f) {
  * // => {type: 'blogpost', title: 'foo'}
  */
 
-_addMethod(Stream, 'findWhere', function (props) {
+addMethod('findWhere', function (props) {
     return this.where(props).take(1);
 }, {expose: true});
 
@@ -2010,7 +2022,7 @@ _addMethod(Stream, 'findWhere', function (props) {
  *
  */
 
-_addMethod(Stream, 'group', function (f) {
+addMethod('group', function (f) {
     var lambda = _.isString(f) ? _.get(f) : f;
     return this.reduce(function (m, o) {
         var key = lambda(o);
@@ -2032,7 +2044,7 @@ _addMethod(Stream, 'group', function (f) {
  * // => 1, 3, 6
  */
 
-_addMethod(Stream, 'compact', function () {
+addMethod('compact', function () {
     return this.filter(function (x) {
         return x;
     });
@@ -2066,7 +2078,7 @@ _addMethod(Stream, 'compact', function () {
  * // => {type: 'blogpost', title: 'bar'}
  */
 
-_addMethod(Stream, 'where', function (props) {
+addMethod('where', function (props) {
     return this.filter(function (x) {
         for (var k in props) {
             if (x[k] !== props[k]) {
@@ -2102,7 +2114,7 @@ _addMethod(Stream, 'where', function (props) {
  *
  */
 
-_addMethod(Stream, 'uniqBy', function (compare) {
+addMethod('uniqBy', function (compare) {
     var uniques = [];
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -2156,7 +2168,7 @@ _addMethod(Stream, 'uniqBy', function (compare) {
  * // => 'yellow'
  */
 
-_addMethod(Stream, 'uniq', function () {
+addMethod('uniq', function () {
     return this.uniqBy(function (a, b) {
         return a === b;
     });
@@ -2191,7 +2203,7 @@ _addMethod(Stream, 'uniq', function () {
  * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
  */
 
-_addMethod(Stream, 'zipAll', function () {
+addMethod('zipAll', function () {
     var returned = 0;
     var z = [];
     var finished = false;
@@ -2253,7 +2265,7 @@ _addMethod(Stream, 'zipAll', function () {
  * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
  */
 
-_addMethod(Stream, 'zipEach', function (ys) {
+addMethod('zipEach', function (ys) {
     return _([this]).concat(_(ys).map(_)).zipAll0();
 }, {expose: true});
 
@@ -2269,7 +2281,7 @@ _addMethod(Stream, 'zipEach', function (ys) {
  * _(['a', 'b', 'c']).zip([1, 2, 3])  // => ['a', 1], ['b', 2], ['c', 3]
  */
 
-_addMethod(Stream, 'zip', function (ys) {
+addMethod('zip', function (ys) {
     return _([this, _(ys)]).zipAll();
 }, {expose: true});
 
@@ -2285,7 +2297,7 @@ _addMethod(Stream, 'zip', function (ys) {
  * _([1, 2, 3, 4, 5]).batch(2)  // => [1, 2], [3, 4], [5]
  */
 
-_addMethod(Stream, 'batch', function (n) {
+addMethod('batch', function (n) {
     return this.batchWithTimeOrCount(-1, n);
 }, {expose: true});
 
@@ -2310,7 +2322,7 @@ _addMethod(Stream, 'batch', function (n) {
  * // => [1, 2], [3], [4]
  */
 
-_addMethod(Stream, 'batchWithTimeOrCount', function (ms, n) {
+addMethod('batchWithTimeOrCount', function (ms, n) {
     var batched = [],
         timeout;
 
@@ -2363,7 +2375,7 @@ _addMethod(Stream, 'batchWithTimeOrCount', function (ms, n) {
  * _(['foo']).intersperse('bar')  // => foo
  */
 
-_addMethod(Stream, 'intersperse', function (separator) {
+addMethod('intersperse', function (separator) {
     var started = false;
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -2402,7 +2414,7 @@ _addMethod(Stream, 'intersperse', function (separator) {
  * _(['foo']).splitBy('bar')  // => foo
  */
 
-_addMethod(Stream, 'splitBy', function (sep) {
+addMethod('splitBy', function (sep) {
     var decoder = new Decoder();
     var buffer = false;
 
@@ -2447,7 +2459,7 @@ _addMethod(Stream, 'splitBy', function (sep) {
  * _(['a\r\nb\nc']]).split()  // => a, b, c
  */
 
-_addMethod(Stream, 'split', function () {
+addMethod('split', function () {
     return this.splitBy(/\r?\n/);
 }, {expose: true});
 
@@ -2467,7 +2479,7 @@ _addMethod(Stream, 'split', function () {
  * _([1, 2, 3, 4]).slice(1, 3) // => 2, 3
  */
 
-_addMethod(Stream, 'slice', function(start, end) {
+addMethod('slice', function(start, end) {
     var index = 0;
     start = typeof start != 'number' || start < 0 ? 0 : start;
     end = typeof end != 'number' ? Infinity : end;
@@ -2510,7 +2522,7 @@ _addMethod(Stream, 'slice', function(start, end) {
  * _([1, 2, 3, 4]).take(2) // => 1, 2
  */
 
-_addMethod(Stream, 'take', function (n) {
+addMethod('take', function (n) {
     var s = this.slice(0, n);
     s.id = 'take:' + s.id;
     return s;
@@ -2530,7 +2542,7 @@ _addMethod(Stream, 'take', function (n) {
  * _([1, 2, 3, 4]).drop(2) // => 3, 4
  */
 
-_addMethod(Stream, 'drop', function (n) {
+addMethod('drop', function (n) {
     return this.slice(n, Infinity);
 }, {expose: true});
 
@@ -2545,7 +2557,7 @@ _addMethod(Stream, 'drop', function (n) {
  * _([1, 2, 3, 4]).head() // => 1
  */
 
-_addMethod(Stream, 'head', function () {
+addMethod('head', function () {
     return this.take(1);
 }, {expose: true});
 
@@ -2560,7 +2572,7 @@ _addMethod(Stream, 'head', function () {
  * _([1, 2, 3, 4]).last()  // => 4
  */
 
-_addMethod(Stream, 'last', function () {
+addMethod('last', function () {
     var nothing = {};
     var prev = nothing;
     return this.consume(function (err, x, push, next) {
@@ -2599,7 +2611,7 @@ _addMethod(Stream, 'last', function () {
  * //=> [4, 3, 2, 1]
  */
 
-_addMethod(Stream, 'sortBy', function (f) {
+addMethod('sortBy', function (f) {
     return this.collect().invoke('sort', [f]).sequence();
 }, {expose: true});
 
@@ -2616,7 +2628,7 @@ _addMethod(Stream, 'sortBy', function (f) {
  * // => ['b', 'g', 'r', 'z']
  */
 
-_addMethod(Stream, 'sort', function () {
+addMethod('sort', function () {
     return this.sortBy();
 }, {expose: true});
 
@@ -2656,7 +2668,7 @@ _addMethod(Stream, 'sort', function () {
  * });
  */
 
-_addMethod(Stream, 'through', function (target) {
+addMethod('through', function (target) {
     var output;
 
     if (_.isFunction(target)) {
@@ -2664,7 +2676,7 @@ _addMethod(Stream, 'through', function (target) {
     }
     else {
         target.pause();
-        output = _();
+        output = this.create();
         this.on('error', writeErr);
         target.on('error', writeErr);
         return this.pipe(target).pipe(output);
@@ -2749,7 +2761,7 @@ _.pipeline = function (/*through...*/) {
  * filenames.map(readFile).sequence()
  */
 
-_addMethod(Stream, 'sequence', function () {
+addMethod('sequence', function () {
     var original = this;
     var curr = this;
     return new this.constructor(function (push, next) {
@@ -2848,7 +2860,7 @@ _.series = _.sequence;
  * nums.flatten();  // => 1, 2, 3, 4, 5, 6
  */
 
-_addMethod(Stream, 'flatten', function () {
+addMethod('flatten', function () {
     var curr = this;
     var stack = [];
     return _(function (push, next) {
@@ -2900,7 +2912,7 @@ _addMethod(Stream, 'flatten', function () {
  * filenames.map(readFile).parallel(10);
  */
 
-_addMethod(Stream, 'parallel', function (n) {
+addMethod('parallel', function (n) {
     var source = this;
     var running = [];
     var ended = false;
@@ -3004,7 +3016,7 @@ _addMethod(Stream, 'parallel', function (n) {
  * _.otherwise(_(['foo']), _([]))         // => 'foo'
  */
 
-_addMethod(Stream, 'otherwise', function (ys) {
+addMethod('otherwise', function (ys) {
     var xs = this;
     return xs.consume(function (err, x, push, next) {
         if (err) {
@@ -3041,7 +3053,7 @@ _addMethod(Stream, 'otherwise', function (ys) {
  * _([1, 2, 3]).append(4)  // => 1, 2, 3, 4
  */
 
-_addMethod(Stream, 'append', function (y) {
+addMethod('append', function (y) {
     return this.consume(function (err, x, push, next) {
         if (x === nil) {
             push(null, y);
@@ -3077,7 +3089,7 @@ _addMethod(Stream, 'append', function (y) {
  * _([1, 2, 3, 4]).reduce(add, 0)  // => 10
  */
 
-_addMethod(Stream, 'reduce', function (f, z) {
+addMethod('reduce', function (f, z) {
     // This can't be implemented with scan(), because we don't know if the
     // errors that we see from the scan were thrown by the iterator or just
     // passed through from the source stream.
@@ -3118,7 +3130,7 @@ _addMethod(Stream, 'reduce', function (f, z) {
  * _([1, 2, 3, 4]).reduce1(add)  // => 10
  */
 
-_addMethod(Stream, 'reduce1', function (f) {
+addMethod('reduce1', function (f) {
     var self = this;
     return _(function (push, next) {
         self.pull(function (err, x) {
@@ -3151,7 +3163,7 @@ _addMethod(Stream, 'reduce1', function (f) {
  * });
  */
 
-_addMethod(Stream, 'collect', function () {
+addMethod('collect', function () {
     var xs = [];
     return this.consume(function (err, x, push, next) {
         if (err) {
@@ -3187,7 +3199,7 @@ _addMethod(Stream, 'collect', function () {
  * _([1, 2, 3, 4]).scan(add, 0)  // => 0, 1, 3, 6, 10
  */
 
-_addMethod(Stream, 'scan', function (f, z) {
+addMethod('scan', function (f, z) {
     var self = this;
     return _([z]).concat(
         self.consume(function (err, x, push, next) {
@@ -3228,7 +3240,7 @@ _addMethod(Stream, 'scan', function (f, z) {
  * _([1, 2, 3, 4]).scan1(add)  // => 1, 3, 6, 10
  */
 
-_addMethod(Stream, 'scan1', function (f) {
+addMethod('scan1', function (f) {
     var self = this;
     return _(function (push, next) {
         self.pull(function (err, x) {
@@ -3292,7 +3304,7 @@ HighlandTransform.prototype['@@transducer/step'] = function (push, input) {
  * // => [2, 3, 4, 5]
  */
 
-_addMethod(Stream, 'transduce', function transduce(xf) {
+addMethod('transduce', function transduce(xf) {
     var transform = null,
         memo = null;
 
@@ -3368,7 +3380,7 @@ _addMethod(Stream, 'transduce', function transduce(xf) {
  * _.concat([3, 4], [1, 2])  // => 1, 2, 3, 4
  */
 
-_addMethod(Stream, 'concat', function (ys) {
+addMethod('concat', function (ys) {
     ys = _(ys);
     return this.consume(function (err, x, push, next) {
         if (x === nil) {
@@ -3403,7 +3415,7 @@ _addMethod(Stream, 'concat', function (ys) {
  * // => contents of foo.txt, bar.txt and baz.txt in the order they were read
  */
 
-_addMethod(Stream, 'merge', function () {
+addMethod('merge', function () {
     var self = this;
     var srcs = [];
 
@@ -3525,7 +3537,7 @@ _addMethod(Stream, 'merge', function () {
  * filenames.map(readFile).sequence().invoke('toString', ['utf8']);
  */
 
-_addMethod(Stream, 'invoke', function (method, args) {
+addMethod('invoke', function (method, args) {
     return this.map(function (x) {
         return x[method].apply(x, args);
     });
@@ -3580,7 +3592,7 @@ _addMethod(Stream, 'invoke', function (method, args) {
  *
  */
 
-_addMethod(Stream, 'nfcall', function (args) {
+addMethod('nfcall', function (args) {
     return this.map(function (x) {
         return _.wrapCallback(x).apply(x, args);
     });
@@ -3599,7 +3611,7 @@ _addMethod(Stream, 'nfcall', function (args) {
  * _('mousemove', document).throttle(1000);
  */
 
-_addMethod(Stream, 'throttle', function (ms) {
+addMethod('throttle', function (ms) {
     var last = 0 - ms;
     return this.consume(function (err, x, push, next) {
         var now = new Date().getTime();
@@ -3636,7 +3648,7 @@ _addMethod(Stream, 'throttle', function (ms) {
  * $('keyup', textbox).debounce(1000);
  */
 
-_addMethod(Stream, 'debounce', function (ms) {
+addMethod('debounce', function (ms) {
     var t = null;
     var nothing = {};
     var last = nothing;
@@ -3683,7 +3695,7 @@ _addMethod(Stream, 'debounce', function (ms) {
  * mousePosition.latest().map(slowThing)
  */
 
-_addMethod(Stream, 'latest', function () {
+addMethod('latest', function () {
     var nothing = {},
         latest = nothing,
         errors = [],
@@ -3848,7 +3860,7 @@ StreamMultiplexer.prototype.newStream = function newStream() {
     self._numConsumers++;
 
     var pull = this.pull.bind(this, id);
-    return new Stream(newDelegateGenerator(pull))
+    return new this._stream.constructor(newDelegateGenerator(pull))
         .onDestroy(function () {
             self.removeConsumer(id);
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -707,7 +707,7 @@ function Stream(generator) {
 inherits(Stream, EventEmitter);
 
 Stream._addMethod = function(name, f, options) {
-    Stream.prototype[name] = f;
+    this.prototype[name] = f;
     var n = f.length;
     var that = this;
     if (options && options.expose) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1142,7 +1142,7 @@ addMethod('consume', function (f) {
 
 /**
  * Consumes a single item from the Stream. Unlike consume, this function will
- * not provide a new stream for you to push values onto, and it will unsubscribe
+ * not provide a n/ew stream for you to push values onto, and it will unsubscribe
  * as soon as it has a single error, value or nil from the source.
  *
  * You probably won't need to use this directly, but it is used internally by
@@ -2736,7 +2736,26 @@ _.pipeline = function (/*through...*/) {
     var end = rest.reduce(function (src, dest) {
         return src.through(dest);
     }, start);
-    return new PipelineWrapperStream(start, end);
+
+    var wrapper = this(function (push, next) {
+        end.pull(function (err, x) {
+            if (err) {
+                push(err);
+                next();
+            }
+            else if (x === nil) {
+                push(null, nil);
+            }
+            else {
+                push(null, x);
+                next();
+            }
+        });
+    });
+    wrapper.write = function(token) {
+        start.write(token);
+    };
+    return wrapper;
 };
 
 /**
@@ -3752,33 +3771,6 @@ addMethod('latest', function () {
         }
     });
 }, {expose: true});
-
-function PipelineWrapperStream(start, end) {
-    var self = this;
-    PipelineWrapperStream.super_.call(self, function (push, next) {
-        end.pull(function (err, x) {
-            if (err) {
-                push(err);
-                next();
-            }
-            else if (x === nil) {
-                push(null, nil);
-            }
-            else {
-                push(null, x);
-                next();
-            }
-        });
-    });
-
-    self._start = start;
-}
-
-inherits(PipelineWrapperStream, Stream);
-
-PipelineWrapperStream.prototype.write = function write(token) {
-    this._start.write(token);
-};
 
 function StreamMultiplexer(stream) {
     this._stream = stream;

--- a/lib/index.js
+++ b/lib/index.js
@@ -701,9 +701,9 @@ function use(Super, originalTopLevel) {
 
 _.use = use(Stream, _);
 
-addMethod('create', function() {
+Stream.prototype.create = function () {
     return __(this.constructor).apply(null, arguments);
-});
+};
 
 /**
  * Used as an Error marker when writing to a Stream's incoming buffer

--- a/lib/index.js
+++ b/lib/index.js
@@ -3633,8 +3633,9 @@ addMethod('invoke', function (method, args) {
  */
 
 addMethod('nfcall', function (args) {
+    var wrap = _.wrapCallback._relevel(this.create.bind(this));
     return this.map(function (x) {
-        return _.wrapCallback(x).apply(x, args);
+        return wrap(x).apply(x, args);
     });
 }, {expose: true});
 

--- a/test/test.js
+++ b/test/test.js
@@ -3302,6 +3302,17 @@ exports['nfcall - returnsSameStream'] = returnsSameStreamTest(function(s) {
     return s.nfcall([]).series();
 }, [1], [function(c) { c(null, 1) }]);
 
+exports['nfcall - wraps same stream'] = function (test) {
+    var s = _.use({
+        foo: true
+    });
+
+    s([function(c) { c(null, 1) }]).nfcall([]).apply(function(xs) {
+        test.ok(xs.foo);
+        test.done();
+    });
+};
+
 exports['nfcall - ArrayStream'] = function (test) {
     function add(n) {
         return function(state, push) {

--- a/test/test.js
+++ b/test/test.js
@@ -58,6 +58,22 @@ function noValueOnErrorTest(transform, expected) {
     }
 }
 
+function returnsSameStreamTest(transform, expected, initial) {
+    var sub = _.use({
+        substream: true
+    });
+    return function (test) {
+        test.expect(2);
+        var s = sub(initial || [1]);
+        var r = transform(s);
+        test.ok(r.substream, 'Returned incorrect stream class');
+        r.toArray(function(xs) {
+            test.same(xs, expected || [1]);
+            test.done();
+        });
+    };
+}
+
 function generatorStream(input, timeout) {
     return _(function (push, next) {
         for (var i = 0, len = input.length; i < len; i++) {
@@ -949,6 +965,10 @@ exports['errors - GeneratorStream'] = function (test) {
     });
 };
 
+exports['errors - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.errors();
+}, [1]);
+
 exports['stopOnError'] = function (test) {
     var errs = [];
     var err1 = new Error('one');
@@ -1029,6 +1049,10 @@ exports['stopOnError - GeneratorStream'] = function (test) {
     });
 };
 
+exports['stopOnError - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.stopOnError();
+}, [1]);
+
 exports['apply'] = function (test) {
     test.expect(8);
     var fn = function (a, b, c) {
@@ -1095,6 +1119,10 @@ exports['take'] = function (test) {
     test.done();
 };
 
+exports['take - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.take(1);
+}, [1]);
+
 exports['slice'] = {
     setUp: function (cb) {
         this.input = [1, 2, 3, 4, 5];
@@ -1141,7 +1169,10 @@ exports['slice'] = {
             .toArray(this.tester([3, 4], test));
         test.done();
     },
-    'noValueOnError': noValueOnErrorTest(_.slice(2, 3))
+    'noValueOnError': noValueOnErrorTest(_.slice(2, 3)),
+    'returnsSameStream': returnsSameStreamTest(function(s) {
+        return s.slice(0, 1);
+    }, [1])
 };
 
 exports['take - noValueOnError'] = noValueOnErrorTest(_.take(1));
@@ -1228,6 +1259,10 @@ exports['drop'] = {
     'noValueOnError': noValueOnErrorTest(_.drop(2))
 };
 
+exports['drop - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.drop(1);
+}, []);
+
 exports['head'] = function (test) {
     test.expect(2);
     var s = _([2, 1]).head();
@@ -1241,6 +1276,10 @@ exports['head'] = function (test) {
 };
 
 exports['head - noValueOnError'] = noValueOnErrorTest(_.head());
+
+exports['head - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.head();
+}, [1]);
 
 exports['each'] = function (test) {
     var calls = [];
@@ -1954,6 +1993,10 @@ exports['sequence - Streams of Streams of Arrays'] = function (test) {
     });
 }
 
+exports['sequence - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.sequence();
+}, [1], [[1]]);
+
 exports['fork'] = function (test) {
     test.expect(9);
     var s = _([1,2,3,4]);
@@ -1994,6 +2037,10 @@ exports['fork'] = function (test) {
 
     test.done();
 };
+
+exports['fork - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.fork();
+}, [1]);
 
 exports['observe'] = function (test) {
     test.expect(11);
@@ -2096,6 +2143,12 @@ exports['observe - observers should be destroyed (issue #208)'] = function (test
     test.done();
 };
 
+/* TODO: not working, doesn't consume
+exports['observe - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.observe();
+}, [1]);
+*/
+
 // TODO: test redirect after fork, forked streams should transfer over
 // TODO: test redirect after observe, observed streams should transfer over
 
@@ -2159,6 +2212,10 @@ exports['flatten - nested GeneratorStreams'] = function (test) {
     });
 };
 
+exports['flatten - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.flatten();
+}, [1], [[1]]);
+
 exports['otherwise'] = function (test) {
     test.expect(5);
     _.otherwise(_([4,5,6]), _([1,2,3])).toArray(function (xs) {
@@ -2179,6 +2236,7 @@ exports['otherwise'] = function (test) {
     });
     test.done();
 };
+
 
 exports['otherwise - noValueOnError'] = noValueOnErrorTest(_.otherwise(_([])));
 
@@ -2273,6 +2331,10 @@ exports['otherwise - function'] = function (test) {
     test.done();
 };
 
+exports['otherwise - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.otherwise([1]);
+}, [1], []);
+
 exports['append'] = function (test) {
     test.expect(2);
     _.append(4, [1,2,3]).toArray(function (xs) {
@@ -2306,6 +2368,10 @@ exports['append - GeneratorStream'] = function (test) {
         test.done();
     });
 };
+
+exports['append - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.append(2);
+}, [1, 2]);
 
 exports['reduce'] = function (test) {
     test.expect(3);
@@ -2363,6 +2429,10 @@ exports['reduce - GeneratorStream'] = function (test) {
         test.done();
     });
 };
+
+exports['reduce - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.reduce(0, _.add);
+}, [3], [1, 2]);
 
 exports['reduce1'] = function (test) {
     test.expect(3);
@@ -2428,6 +2498,9 @@ exports['reduce1 - GeneratorStream'] = function (test) {
     });
 };
 
+exports['reduce1 - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.reduce1(_.add);
+}, [3], [1, 2]);
 
 exports['scan'] = function (test) {
     test.expect(3);
@@ -2516,6 +2589,10 @@ exports['scan - GeneratorStream lazy'] = function (test) {
         test.done();
     });
 };
+
+exports['scan - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.scan(0, _.add);
+}, [0, 1, 3], [1, 2]);
 
 exports['scan1'] = function (test) {
     test.expect(3);
@@ -2607,6 +2684,10 @@ exports['scan1 - GeneratorStream lazy'] = function (test) {
     });
 };
 
+exports['scan1 - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.scan1(_.add);
+}, [1, 3], [1, 2]);
+
 exports['collect'] = function (test) {
     _.collect([1,2,3,4]).toArray(function (xs) {
         test.same(xs, [[1,2,3,4]]);
@@ -2638,6 +2719,10 @@ exports['collect - GeneratorStream'] = function (test) {
         test.done();
     });
 };
+
+exports['collect - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.collect();
+}, [[1]]);
 
 exports['transduce'] = {
     setUp: function (cb) {
@@ -2782,6 +2867,12 @@ exports['transduce'] = {
     },
     'noValueOnError': function (test) {
         noValueOnErrorTest(_.transduce(this.xf))(test);
+    },
+    'returnsSameStream': function (test) {
+        var self = this;
+        returnsSameStreamTest(function(s) {
+            return s.transduce(self.xf);
+        }, [2])(test);
     }
 };
 
@@ -2862,6 +2953,10 @@ exports['concat - GeneratorStream'] = function (test) {
         test.done();
     });
 };
+
+exports['concat - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.concat([2]);
+}, [1, 2]);
 
 exports['merge'] = {
     setUp: function (callback) {
@@ -3119,6 +3214,9 @@ exports['merge'] = {
         this.clock.tick(400);
     },
     'noValueOnError': noValueOnErrorTest(_.merge()),
+    'returnsSameStream': returnsSameStreamTest(function(s) {
+        return s.merge();
+    }, [1], [_([1])]),
     'pass through errors (issue #141)': function (test) {
         test.expect(1);
 
@@ -3147,6 +3245,10 @@ exports['invoke'] = function (test) {
 };
 
 exports['invoke - noValueOnError'] = noValueOnErrorTest(_.invoke('toString', []));
+
+exports['invoke - returnsSameStreamTest'] = returnsSameStreamTest(function(s) {
+    return s.invoke('toString', []);
+}, ['1']);
 
 exports['invoke - ArrayStream'] = function (test) {
     _([1,2,3,4]).invoke('toString', []).toArray(function (xs) {
@@ -3195,6 +3297,10 @@ exports['nfcall'] = function (test) {
 };
 
 exports['nfcall - noValueOnError'] = noValueOnErrorTest(_.nfcall([]));
+
+exports['nfcall - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.nfcall([]).series();
+}, [1], [function(c) { c(null, 1) }]);
 
 exports['nfcall - ArrayStream'] = function (test) {
     function add(n) {
@@ -3270,6 +3376,10 @@ exports['map'] = function (test) {
 };
 
 exports['map - noValueOnError'] = noValueOnErrorTest(_.map(function (x) { return x }));
+
+exports['map - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.map(function (x) { return x });
+});
 
 exports['map - argument function throws'] = function (test) {
     test.expect(6);
@@ -3353,6 +3463,10 @@ exports['doto'] = function (test) {
 
 exports['doto - noValueOnError'] = noValueOnErrorTest(_.doto(function (x) { return x }));
 
+exports['doto - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.doto(function (x) { return x });
+});
+
 exports['tap - doto alias'] = function (test) {
     test.expect(2);
 
@@ -3378,6 +3492,10 @@ exports['flatMap'] = function (test) {
 };
 
 exports['flatMap - noValueOnError'] = noValueOnErrorTest(_.flatMap(function (x) { return _() }));
+
+exports['flatMap - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.flatMap(function (x) { return _([x]) });
+});
 
 exports['flatMap - argument function throws'] = function (test) {
     test.expect(4);
@@ -3460,6 +3578,10 @@ exports['pluck'] = function (test) {
 
 exports['pluck - noValueOnError'] = noValueOnErrorTest(_.pluck('foo'));
 
+exports['pluck - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.pluck('foo');
+}, ['bar'], [{foo: 'bar'}]);
+
 exports['pluck - non-object argument'] = function (test) {
     var a = _([1, {type: 'blogpost', title: 'foo'}]);
     test.throws(function () {
@@ -3505,6 +3627,10 @@ exports['pick'] = function (test) {
 };
 
 exports['pick - noValueOnError'] = noValueOnErrorTest(_.pick(['plug']));
+
+exports['pick - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.pick(['foo']);
+}, [{foo: 'bar'}], [{foo: 'bar', baz: 'quux'}]);
 
 exports['pick - non-existant property'] = function (test) {
     test.expect(9);
@@ -3634,6 +3760,10 @@ exports['pickBy'] = function (test) {
 };
 
 exports['pickBy - noValueOnError'] = noValueOnErrorTest(_.pickBy(' '));
+
+exports['pickBy - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.pickBy(function(k) {return k === 'foo'});
+}, [{foo: 'bar'}], [{foo: 'bar'}]);
 
 exports['pickBy - non-existant property'] = function (test) {
     test.expect(3);
@@ -3770,6 +3900,10 @@ exports['filter'] = function (test) {
 
 exports['filter - noValueOnError'] = noValueOnErrorTest(_.filter(function (x) { return true }));
 
+exports['filter - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.filter(function (x) { return true });
+});
+
 exports['filter - argument function throws'] = function (test) {
     test.expect(3);
     var err = new Error('error');
@@ -3825,6 +3959,10 @@ exports['flatFilter'] = function (test) {
 };
 
 exports['flatFilter - noValueOnError'] = noValueOnErrorTest(_.flatFilter(function (x) { return _([true]) }));
+
+exports['flatFilter - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.flatFilter(function (x) { return _([true]) });
+});
 
 exports['flatFilter - argument function throws'] = function (test) {
     test.expect(4);
@@ -3899,6 +4037,10 @@ exports['reject'] = function (test) {
 
 exports['reject - noValueOnError'] = noValueOnErrorTest(_.reject(function (x) { return false }));
 
+exports['reject - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.reject(function (x) { return false });
+});
+
 exports['reject - ArrayStream'] = function (test) {
     function isEven(x) {
         return x % 2 === 0;
@@ -3953,6 +4095,10 @@ exports['find'] = function (test) {
 };
 
 exports['find - noValueOnError'] = noValueOnErrorTest(_.find(function (x) { return true }));
+
+exports['find - returnsSameStreamTest'] = returnsSameStreamTest(function(s) {
+    return s.find(function (x) { return true });
+});
 
 exports['find - argument function throws'] = function (test) {
     test.expect(4);
@@ -4083,6 +4229,10 @@ exports['find - GeneratorStream'] = function (test) {
 
     exports['group - noValueOnError'] = noValueOnErrorTest(_.group('foo'), [{}]);
 
+    exports['group - returnsSameStream'] = returnsSameStreamTest(function(s) {
+        return s.group('foo');
+    }, [{bar: [{foo: 'bar'}]}], [{foo: 'bar'}]);
+
     exports['group - primatives'] = function (test) {
         test.expect(5);
 
@@ -4163,6 +4313,10 @@ exports['compact'] = function (test) {
 
 exports['compact - noValueOnError'] = noValueOnErrorTest(_.compact());
 
+exports['compact - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.compact();
+});
+
 exports['compact - ArrayStream'] = function (test) {
     _([0, 1, false, 3, undefined, null, 6]).compact().toArray(function (xs) {
         test.same(xs, [1, 3, 6]);
@@ -4198,6 +4352,10 @@ exports['where'] = function (test) {
 };
 
 exports['where - noValueOnError'] = noValueOnErrorTest(_.where({'foo': 'bar'}));
+
+exports['where - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.where({'foo': 'bar'});
+}, []);
 
 exports['where - ArrayStream'] = function (test) {
     test.expect(2);
@@ -4262,6 +4420,9 @@ exports['findWhere'] = function (test) {
 };
 
 exports['findWhere - noValueOnError'] = noValueOnErrorTest(_.findWhere({'foo': 'bar'}));
+exports['findWhere - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.findWhere({'foo': 'bar'});
+}, []);
 
 exports['findWhere - ArrayStream'] = function (test) {
     test.expect(2);
@@ -4328,6 +4489,10 @@ exports['uniqBy - compare error'] = function(test) {
 
 exports['uniqBy - noValueOnError'] = noValueOnErrorTest(_.uniqBy(function(a,b) { return a === b }));
 
+exports['uniqBy - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.uniqBy(function(a,b) { return a === b });
+});
+
 exports['uniq'] = function(test) {
     test.expect(1);
     var xs = [ 'blue', 'red', 'red', 'yellow', 'blue', 'red' ]
@@ -4338,6 +4503,10 @@ exports['uniq'] = function(test) {
 };
 
 exports['uniq - noValueOnError'] = noValueOnErrorTest(_.uniq());
+
+exports['uniq - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.uniq();
+});
 
 exports['zip'] = function (test) {
     test.expect(2);
@@ -4352,6 +4521,10 @@ exports['zip'] = function (test) {
 };
 
 exports['zip - noValueOnError'] = noValueOnErrorTest(_.zip([1]));
+
+exports['zip - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.zip([1]);
+}, [[1,1]]);
 
 exports['zip - source emits error'] = function (test) {
     test.expect(4);
@@ -4430,6 +4603,10 @@ exports['zipEach'] = function (test) {
 };
 
 exports['zipEach - noValueOnError'] = noValueOnErrorTest(_.zipEach([1]));
+
+exports['zipEach - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.zipEach([[1]]);
+}, [[1,1]]);
 
 exports['zipEach - StreamOfStreams'] = function (test) {
     test.expect(1);
@@ -4539,6 +4716,9 @@ exports['zipAll'] = {
         test.done();
     },
     'noValueOnError': noValueOnErrorTest(_.zipAll),
+    'returnsSameStream': returnsSameStreamTest(function(s) {
+        return s.zipAll();
+    }, [[1, 1]], [_([1]), _([1])]),
     'source emits error': function (test) {
         test.expect(5);
         var self = this;
@@ -4618,6 +4798,9 @@ exports['batch'] = function (test) {
 };
 
 exports['batch - noValueOnError'] = noValueOnErrorTest(_.batch(1));
+exports['batch - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.batch(1);
+}, [[1]]);
 
 exports['batch - ArrayStream'] = function (test) {
     test.expect(5);
@@ -4717,6 +4900,9 @@ exports['batchWithTimeOrCount'] = {
 };
 
 exports['batchWithTimeOrCount - noValueOnError'] = noValueOnErrorTest(_.batchWithTimeOrCount(10, 2));
+exports['batchWithTimeOrCount - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.batchWithTimeOrCount(10, 2);
+}, [[1]]);
 
 exports['splitBy'] = function(test) {
     test.expect(3);
@@ -4745,6 +4931,10 @@ exports['splitBy - delimiter at end of stream'] = function(test) {
 };
 
 exports['splitBy - noValueOnError'] = noValueOnErrorTest(_.splitBy(' '));
+
+exports['splitBy - returnsSameStreamTest'] = returnsSameStreamTest(function(s) {
+    return s.splitBy(' ');
+}, ['hello', 'world'], ['hello world']);
 
 exports['splitBy - unicode'] = function (test) {
     // test case borrowed from 'split' by dominictarr
@@ -4821,6 +5011,10 @@ exports['intersperse'] = function(test) {
 
 exports['intersperse - noValueOnError'] = noValueOnErrorTest(_.intersperse(1));
 
+exports['intersperse - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.intersperse(1);
+});
+
 exports['intersperse - ArrayStream'] = function(test) {
     test.expect(3);
     _(['ba', 'a', 'a']).intersperse('n').toArray(function (xs) {
@@ -4883,6 +5077,10 @@ exports['parallel'] = function (test) {
 };
 
 exports['parallel - noValueOnError'] = noValueOnErrorTest(_.parallel(1));
+
+exports['parallel - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.parallel(1);
+}, [1], [_([1])]);
 
 exports['parallel - partial application'] = function (test) {
     var calls = [];
@@ -5239,7 +5437,10 @@ exports['throttle'] = {
         });
         this.clock.tick(90);
     },
-    'noValueOnError': noValueOnErrorTest(_.throttle(10))
+    'noValueOnError': noValueOnErrorTest(_.throttle(10)),
+    'returnsSameStream': returnsSameStreamTest(function(s) {
+        return s.throttle(10);
+    })
 };
 
 exports['debounce'] = {
@@ -5326,7 +5527,10 @@ exports['debounce'] = {
         });
         this.clock.tick(300);
     },
-    'noValueOnError': noValueOnErrorTest(_.debounce(10))
+    'noValueOnError': noValueOnErrorTest(_.debounce(10)),
+    'returnsSameStream': returnsSameStreamTest(function(s) {
+        return s.debounce(10);
+    })
 };
 
 exports['latest'] = {
@@ -5439,7 +5643,10 @@ exports['latest'] = {
         });
         this.clock.tick(1000);
         test.done();
-    }
+    },
+    returnsSameStream: returnsSameStreamTest(function(s) {
+        return s.latest();
+    })
 };
 
 exports['last'] = function (test) {
@@ -5457,6 +5664,9 @@ exports['last'] = function (test) {
 };
 
 exports['last - noValueOnError'] = noValueOnErrorTest(_.last());
+exports['last - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.last();
+});
 
 exports['sortBy'] = {
     setUp: function (cb) {
@@ -5483,7 +5693,13 @@ exports['sortBy'] = {
         _.sortBy(this.compDesc)(s).toArray(this.tester(this.reversed, test));
         test.done();
     },
-    'noValueOnError': noValueOnErrorTest(_.sortBy(this.compDesc))
+    'noValueOnError': noValueOnErrorTest(_.sortBy(this.compDesc)),
+    'returnsSameStream': function(test) {
+        var self = this;
+        returnsSameStreamTest(function(s) {
+            return s.sortBy(self.compDesc);
+        })(test);
+    }
 };
 
 exports['sort'] = {
@@ -5508,7 +5724,10 @@ exports['sort'] = {
         _.sortBy(this.compDesc)(s).toArray(this.tester(this.sorted, test));
         test.done();
     },
-    'noValueOnError': noValueOnErrorTest(_.sort())
+    'noValueOnError': noValueOnErrorTest(_.sort()),
+    'returnsSameStream': returnsSameStreamTest(function(s) {
+        return s.sort();
+    })
 };
 
 exports['through'] = {
@@ -5611,6 +5830,17 @@ exports['through'] = {
     },
     'noValueOnError': function (test) {
         noValueOnErrorTest(_.through(function (x) { return x }))(test);
+    },
+    'returnsSameStream - function': function (test) {
+        returnsSameStreamTest(function(s) {
+            return s.through(function (x) { return x });
+        })(test);
+    },
+    'returnsSameStream - stream': function (test) {
+        var self = this;
+        returnsSameStreamTest(function(s) {
+            return s.through(self.parser);
+        }, this.numArray, this.stringArray)(test);
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -6083,6 +6083,17 @@ exports['wrapCallback - errors'] = function (test) {
     test.done();
 };
 
+exports['wrapCallback - substream'] = function (test) {
+    var s = _.use({
+        foo: true
+    });
+    var f = function (cb) {
+        cb(null, 'hello');
+    };
+    test.ok(s.wrapCallback(f)().foo);
+    test.done();
+};
+
 exports['streamifyAll'] = {
     'throws when passed a non-function non-object': function (test) {
         test.throws(function () {
@@ -6175,6 +6186,19 @@ exports['streamifyAll'] = {
         test.doesNotThrow(function () {
             _.streamifyAll(ExampleClass);
         });
+        test.done();
+    },
+    'substream': function (test) {
+        var s = _.use({
+            foo: true
+        });
+        var obj = s.streamifyAll({
+            bar: function(cb) {
+                cb(null, 'hello');
+            }
+        });
+
+        test.ok(obj.barStream().foo);
         test.done();
     }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -5967,23 +5967,23 @@ exports['not'] = function (test) {
     return test.done();
 };
 
-exports['subclass'] = {
-    "creates a subclass of Stream": function (test) {
-        var Sub = _.subclass();
+exports['use'] = {
+    "creates a use of Stream": function (test) {
+        var Sub = _.use();
         test.ok(new Sub instanceof Sub);
         test.ok(new Sub instanceof _);
         test.done();
     },
 
     "can be called without new, like Stream": function (test) {
-        var Sub = _.subclass();
+        var Sub = _.use();
         test.ok(Sub() instanceof Sub);
         test.ok(Sub() instanceof _);
         test.done();
     },
 
     "streams": function (test) {
-        var Sub = _.subclass();
+        var Sub = _.use();
         Sub([1, 2, 3]).toArray(function(xs) {
             test.same(xs, [1, 2, 3]);
             test.done();
@@ -5991,14 +5991,14 @@ exports['subclass'] = {
     },
 
     "returns streams of the same type": function(test) {
-        var Sub = _.subclass();
+        var Sub = _.use();
         var s = Sub([1, 2, 3]).map(function(i) { return i });
         test.ok(s instanceof Sub);
         test.done();
     },
 
     "attatches methods": function(test) {
-        var Sub = _.subclass({
+        var Sub = _.use({
             foo: function() {
                 return this;
             }

--- a/test/test.js
+++ b/test/test.js
@@ -5966,3 +5966,46 @@ exports['not'] = function (test) {
     test.equal(_.not(undefined), true);
     return test.done();
 };
+
+exports['subclass'] = {
+    "creates a subclass of Stream": function (test) {
+        var Sub = _.subclass();
+        test.ok(new Sub instanceof Sub);
+        test.ok(new Sub instanceof _);
+        test.done();
+    },
+
+    "can be called without new, like Stream": function (test) {
+        var Sub = _.subclass();
+        test.ok(Sub() instanceof Sub);
+        test.ok(Sub() instanceof _);
+        test.done();
+    },
+
+    "streams": function (test) {
+        var Sub = _.subclass();
+        Sub([1, 2, 3]).toArray(function(xs) {
+            test.same(xs, [1, 2, 3]);
+            test.done();
+        });
+    },
+
+    "returns streams of the same type": function(test) {
+        var Sub = _.subclass();
+        var s = Sub([1, 2, 3]).map(function(i) { return i });
+        test.ok(s instanceof Sub);
+        test.done();
+    },
+
+    "attatches methods": function(test) {
+        var Sub = _.subclass({
+            foo: function() {
+                return this;
+            }
+        });
+
+        var s = Sub();
+        test.equal(s.foo(), s);
+        test.done();
+    }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -2431,7 +2431,7 @@ exports['reduce - GeneratorStream'] = function (test) {
 };
 
 exports['reduce - returnsSameStream'] = returnsSameStreamTest(function(s) {
-    return s.reduce(0, _.add);
+    return s.reduce(_.add, 0);
 }, [3], [1, 2]);
 
 exports['reduce1'] = function (test) {
@@ -2591,7 +2591,7 @@ exports['scan - GeneratorStream lazy'] = function (test) {
 };
 
 exports['scan - returnsSameStream'] = returnsSameStreamTest(function(s) {
-    return s.scan(0, _.add);
+    return s.scan(_.add, 0);
 }, [0, 1, 3], [1, 2]);
 
 exports['scan1'] = function (test) {
@@ -3773,7 +3773,7 @@ exports['pickBy'] = function (test) {
 exports['pickBy - noValueOnError'] = noValueOnErrorTest(_.pickBy(' '));
 
 exports['pickBy - returnsSameStream'] = returnsSameStreamTest(function(s) {
-    return s.pickBy(function(k) {return k === 'foo'});
+    return s.pickBy(function(v, k) {return k === 'foo'});
 }, [{foo: 'bar'}], [{foo: 'bar'}]);
 
 exports['pickBy - non-existant property'] = function (test) {

--- a/test/test.js
+++ b/test/test.js
@@ -6011,5 +6011,16 @@ exports['use'] = {
         test.equal(typeof t.foo, 'function');
         test.equal(typeof s.foo, 'undefined');
         test.done();
+    },
+
+    "casts between streams": function(test) {
+        var A = _.use({
+            foo: function() {
+                return this;
+            }
+        });
+        var B = _.use();
+        test.equal(typeof A.foo(B()).foo, 'function');
+        test.done();
     }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -6013,7 +6013,7 @@ exports['use'] = {
         test.done();
     },
 
-    "casts between streams": function(test) {
+    "casts between streams calling methods": function(test) {
         var A = _.use({
             foo: function() {
                 return this;
@@ -6021,6 +6021,17 @@ exports['use'] = {
         });
         var B = _.use();
         test.equal(typeof A.foo(B()).foo, 'function');
+        test.done();
+    },
+
+    "casts between streams calling topLevel": function(test) {
+        var A = _.use({
+            foo: function() {
+                return this;
+            }
+        });
+        var B = _.use();
+        test.equal(typeof A(B()).foo, 'function');
         test.done();
     }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -6007,5 +6007,17 @@ exports['use'] = {
         var s = Sub();
         test.equal(s.foo(), s);
         test.done();
+    },
+
+    "doesn't modify original environment": function(test) {
+        var Sub = _.use({
+            foo: function() {}
+        });
+        
+        var s = _();
+        var t = Sub();
+        test.equal(typeof t.foo, 'function');
+        test.equal(typeof s.foo, 'undefined');
+        test.done();
     }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -5968,17 +5968,9 @@ exports['not'] = function (test) {
 };
 
 exports['use'] = {
-    "creates a use of Stream": function (test) {
+    "creates a new Stream environment": function (test) {
         var Sub = _.use();
-        test.ok(new Sub instanceof Sub);
-        test.ok(new Sub instanceof _);
-        test.done();
-    },
-
-    "can be called without new, like Stream": function (test) {
-        var Sub = _.use();
-        test.ok(Sub() instanceof Sub);
-        test.ok(Sub() instanceof _);
+        test.ok(_.isStream(Sub()));
         test.done();
     },
 
@@ -5991,9 +5983,9 @@ exports['use'] = {
     },
 
     "returns streams of the same type": function(test) {
-        var Sub = _.use();
+        var Sub = _.use({foo: true});
         var s = Sub([1, 2, 3]).map(function(i) { return i });
-        test.ok(s instanceof Sub);
+        test.ok(s.foo);
         test.done();
     },
 

--- a/test/test.js
+++ b/test/test.js
@@ -5910,6 +5910,21 @@ exports['pipeline - no arguments'] = function (test) {
     });
 };
 
+exports['pipeline - substream'] = function (test) {
+    var s = _.use({
+        foo: true
+    });
+
+    var src = streamify([1]);
+
+    var through = s.pipeline(function(s) {
+        return s;
+    });
+
+    test.ok(src.pipe(through).foo);
+    test.done();
+};
+
 
 // TODO: test lazy getting of values from obj keys (test using getters?)
 exports['values'] = function (test) {

--- a/test/test.js
+++ b/test/test.js
@@ -6313,5 +6313,17 @@ exports['use'] = {
         var B = _.use();
         test.equal(typeof A(B()).foo, 'function');
         test.done();
+    },
+
+    "can add methods directly to topLevel": function(test) {
+        var Sub = _.use({
+            foo: true
+        }, {
+            bar: function() {
+                return this();
+            }
+        });
+        test.ok(Sub.bar().foo);
+        test.done();
     }
 };


### PR DESCRIPTION
Migrating from #324. Still to do:

- [x] Port to 3.0 (`_` vs `Stream`, `use(Stream, ...)`)
- [x] Methods from an `A` stream called on a `B` stream should return an `A` stream
- [x] Calling the constructor on another stream should cast to the first stream
- [x] Test methods returning same extended stream
- [x] `wrapCallback` and `streamifyAll`
- [x] expose everything
- [x] pipeline
- [x] addMethod('create') vs Stream.prototype.create