### PR TITLE
Point to through in pipe docs.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -874,6 +874,11 @@ Stream.prototype.end = function () {
  *
  * This function returns the destination so you can chain together pipe calls.
  *
+ * Like [Readable#pipe](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options),
+ * this function will throw errors if there is no `error` handler installed on
+ * the stream. Use [through](#through) if you are piping to another Highland
+ * stream and want errors as well as values to be propagated.
+ *
  * @id pipe
  * @section Consumption
  * @name Stream.pipe(dest)


### PR DESCRIPTION
Pipe won't automatically propagate errors to the destination stream,
but through will. Tell users about this fact.