### PR TITLE
Adding a Stream.splitByWithTimeout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2451,8 +2451,53 @@ exposeMethod('intersperse');
  */
 
 Stream.prototype.splitBy = function (sep) {
+    return this.splitByWithTimeout(sep, 0);
+};
+exposeMethod('splitBy');
+
+/**
+ * Identical to splitBy but includes a timeout. If the stream is inactive for longer than the timeout the buffer
+ * contents is emitted immediately.
+ *
+ * @id splitByWithTimeout
+ * @section Transforms
+ * @name Stream.splitByWithTimeout(sep, ms)
+ * @param sep - the separator to split on
+ * @param ms - the timeout in milliseconds
+ * @api public
+ *
+ * _(function (push) {
+ *     push('1\n');
+ *     push('2\n');
+ *     push('3');
+ *     setTimeout(push, 200, '4');
+ * }).splitByWithTimeout('\n', 100)
+ *
+ * // => ['1', '2', '3', '4']
+ */
+
+Stream.prototype.splitByWithTimeout = function (sep, ms) {
     var decoder = new Decoder();
     var buffer = false;
+
+    var timeoutHandle = false;
+    function watcher(push) {
+        if (!ms || ms < 1) {
+            return;
+        }
+        clearWatcher();
+        timeoutHandle = setTimeout(function () {
+            push(null, buffer);
+            buffer = false;
+            timeoutHandle = false;
+        }, ms);
+    }
+    function clearWatcher() {
+        if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+        }
+        timeoutHandle = false;
+    }
 
     function drain(x, push) {
         buffer = (buffer || '') + decoder.write(x);
@@ -2465,6 +2510,7 @@ Stream.prototype.splitBy = function (sep) {
     }
 
     return this.consume(function (err, x, push, next) {
+        watcher(push);
         if (err) {
             push(err);
             next();
@@ -2474,6 +2520,7 @@ Stream.prototype.splitBy = function (sep) {
                 drain(decoder.end(), push);
                 push(null, buffer);
             }
+            clearWatcher();
             push(null, nil);
         }
         else {
@@ -2482,7 +2529,7 @@ Stream.prototype.splitBy = function (sep) {
         }
     });
 };
-exposeMethod('splitBy');
+exposeMethod('splitByWithTimeout');
 
 /**
  * [splitBy](#splitBy) over newlines.


### PR DESCRIPTION
The current splitBy method will leave the buffer unsent indefinetly if the separator is not detected.
For quick moving streams, this doesn't cause a problem but for some cases, with slower streams,
we want the buffer contents to be sent after a specific amount of time. Otherwise we are eternally one
step behind.