### PR TITLE
Keep a reference to the correct consumer/observer array in _send (resolves  #366).

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -688,14 +688,20 @@ Stream.prototype._send = function (err, x) {
     }
     if (this._consumers.length) {
         token = err ? new StreamError(err) : x;
-        for (var i = 0, len = this._consumers.length; i < len; i++) {
-            this._consumers[i].write(token);
+        // this._consumers may be changed from under us,
+        // so we keep a copy.
+        var consumers = this._consumers;
+        for (var i = 0, len = consumers.length; i < len; i++) {
+            consumers[i].write(token);
         }
     }
     if (this._observers.length) {
         token = err ? new StreamError(err) : x;
-        for (var j = 0, len2 = this._observers.length; j < len2; j++) {
-            this._observers[j].write(token);
+        // this._observers may be changed from under us,
+        // so we keep a copy.
+        var observers = this._observers;
+        for (var j = 0, len2 = observers.length; j < len2; j++) {
+            observers[j].write(token);
         }
     }
     if (this._send_events) {


### PR DESCRIPTION
We iterate through the `_consumers` and `_observers` arrays in `_send`, but the the arrays may be modified during iteration, so we need to keep a copy of the original reference around.