### PR TITLE
Fix 'fork' when forks start consuming before all forks registered.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1221,6 +1221,10 @@ addMethod('consume', function (f) {
 
 addMethod('pull', function (f) {
     // console.log(this.id, 'pull', this._outgoing.toArray(), this.paused);
+    if (f == null) {
+        throw new Error('Cannot pull() with a null callback.');
+    }
+
     if (this._request) {
         f(new Error('Cannot service a second pull() request while one is in progress.'));
     }
@@ -3835,16 +3839,48 @@ function StreamMultiplexer(stream) {
     this._repeatEmit = false;
     this._numConsumers = 0;
     this._requests = 0;
+    this._cached_value = null;
     this.paused = true;
+
+    var self = this;
+    this._pullCb = function _pullCb(err, x) {
+        self.paused = true;
+        if (self._requests === self._numConsumers) {
+            self._send(err, x);
+        }
+        else {
+            self._saved_token = [err, x];
+        }
+    };
 }
 
+/**
+ * Emit downstream. The caller must guarantee that
+ * this._requests === this._numConsumers.
+ *
+ * @param err - an error.
+ * @param x - a value.
+ */
+
+StreamMultiplexer.prototype._send = function _send(err, x) {
+    // Save all of the current callbacks. This is important because
+    // calling them may cause pull to be called again.
+    var callbacks = [];
+    for (var key in this._consumers) {
+        callbacks.push(this._consumers[key]);
+        this._consumers[key] = null;
+    }
+    this._requests = 0;
+
+    callbacks.forEach(function (cb) {
+        cb(err, x);
+    });
+};
 
 /**
  * Emit if we've met the backpressure requirements.
  */
-StreamMultiplexer.prototype._emit = function resume() {
-    var self = this;
-
+StreamMultiplexer.prototype._resume = function _resume() {
     if (this._emitting) {
         this._repeatEmit = true;
         return;
@@ -3856,30 +3892,18 @@ StreamMultiplexer.prototype._emit = function resume() {
         this._repeatEmit = false;
 
         if (this._requests === this._numConsumers) {
-            this.paused = false;
-
-            // Save all of the current callbacks. This is important because
-            // calling them may cause pull to be called again.
-            var callbacks = [];
-            for (var key in this._consumers) {
-                callbacks.push(this._consumers[key]);
-                this._consumers[key] = null;
-                this._requests--;
+            if (this._saved_token) {
+                var token = this._saved_token;
+                this._saved_token = null;
+                this.paused = true;
+                this._send(token[0], token[1]);
+            } else if (this.paused) {
+                this.paused = false;
+                this._stream.pull(this._pullCb);
             }
-
-            this._stream.pull(pullCb(callbacks));
         }
     } while (this._repeatEmit);
     this._emitting = false;
-
-    function pullCb(callbacks) {
-        return function (err, x) {
-            callbacks.forEach(function (cb) {
-                cb(err, x);
-            });
-            self.paused = true;
-        };
-    }
 };
 
 StreamMultiplexer.prototype.pull = function pull(id, cb) {
@@ -3895,7 +3919,7 @@ StreamMultiplexer.prototype.pull = function pull(id, cb) {
     this._consumers[id] = cb;
     this._requests++;
 
-    this._emit();
+    this._resume();
 };
 
 StreamMultiplexer.prototype.newStream = function newStream() {
@@ -3924,7 +3948,7 @@ StreamMultiplexer.prototype.removeConsumer = function removeConsumer(id) {
     delete this._consumers[id];
     this._numConsumers--;
 
-    this._emit();
+    this._resume();
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -3863,18 +3863,15 @@ function StreamMultiplexer(stream) {
  */
 
 StreamMultiplexer.prototype._send = function _send(err, x) {
-    // Save all of the current callbacks. This is important because
-    // calling them may cause pull to be called again.
-    var callbacks = [];
-    for (var key in this._consumers) {
-        callbacks.push(this._consumers[key]);
-        this._consumers[key] = null;
-    }
+    // Take a snapshot of the current consumers since calling the callbacks
+    // may trigger more consumers to be registered.
+    var consumers = this._consumers;
+    this._consumers = {};
     this._requests = 0;
 
-    callbacks.forEach(function (cb) {
-        cb(err, x);
-    });
+    for (var key in consumers) {
+        consumers[key](err, x);
+    }
 };
 
 /**


### PR DESCRIPTION
This is an unrelated bug to #366, but was by inspired by it and is triggered by the same kind of code.

We used to freeze the set of consumers to which we emit data in `fork` as soon as the backpressure is relieved (which is when we `pull` from the source). However, if a new fork is added after we `pull` from the source, but before the `pull` completes, we will only emit the values to the original set of consumers rather than the new one.

This PR fixes that behavior.