### PR TITLE
Fixes #366. Shallow copy _consumers and _observers list before writing to them

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -681,21 +681,23 @@ _._isStreamRedirect = function (x) {
 
 Stream.prototype._send = function (err, x) {
     //console.log(['_send', this.id, err, x]);
-    var token;
+    var token, consumers, observers;
 
     if (x === nil) {
         this.ended = true;
     }
     if (this._consumers.length) {
+        consumers = this._consumers.slice();
         token = err ? new StreamError(err) : x;
-        for (var i = 0, len = this._consumers.length; i < len; i++) {
-            this._consumers[i].write(token);
+        for (var i = 0, len = consumers.length; i < len; i++) {
+            consumers[i].write(token);
         }
     }
     if (this._observers.length) {
+        observers = this._observers.slice();
         token = err ? new StreamError(err) : x;
-        for (var j = 0, len2 = this._observers.length; j < len2; j++) {
-            this._observers[j].write(token);
+        for (var j = 0, len2 = observers.length; j < len2; j++) {
+            observers[j].write(token);
         }
     }
     if (this._send_events) {

--- a/test/test.js
+++ b/test/test.js
@@ -369,6 +369,21 @@ exports['consume - push nil async (issue #173)'] = function (test) {
     });
 };
 
+exports['consume - consume push mutates _consumers list (issue #366)'] = function (test) {
+    test.expect(1);
+    var spy =  sinon.spy();
+
+    var s = _();
+    s.tap(noop).tap(noop).each(noop).done(spy);
+    s.fork().tap(noop).each(noop).done(spy);
+    s.end();
+
+    function noop () {}
+
+    test.equals(spy.callCount, 2);
+    test.done();
+};
+
 exports['constructor'] = {
     setUp: function (callback) {
         this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
Creates a shallow copy of _consumers and _observers before iterating them.