### PR TITLE
Properly exert backpressure for pipeline-constructed streams.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -379,6 +379,10 @@ _.seq = function () {
     };
 };
 
+function nop() {
+    // Do nothing.
+}
+
 function pipeReadable(xs, stream) {
     // write any errors into the stream
     xs.on('error', writeStreamError);
@@ -467,6 +471,55 @@ function hintMapper(mappingHint) {
 
     return mapper;
 }
+
+function pipeStream(src, dest, write, end, passAlongErrors) {
+    var resume = null;
+    var s = src.consume(function (err, x, push, next) {
+        var canContinue;
+        if (err) {
+            if (passAlongErrors) {
+                canContinue = write.call(dest, new StreamError(err));
+            }
+            else {
+                src.emit('error', err);
+                canContinue = true;
+            }
+        }
+        else if (x === nil) {
+            end.call(dest);
+            return;
+        }
+        else {
+            canContinue = write.call(dest, x);
+        }
+
+        if (canContinue !== false) {
+            next();
+        }
+        else {
+            resume = next;
+        }
+    });
+
+    dest.on('drain', onConsumerDrain);
+
+    // Since we don't keep a reference to piped-to streams,
+    // save a callback that will unbind the event handler.
+    src._destructors.push(function () {
+        dest.removeListener('drain', onConsumerDrain);
+    });
+
+    s.resume();
+    return dest;
+
+    function onConsumerDrain() {
+        if (resume) {
+            resume();
+            resume = null;
+        }
+    }
+}
+
 
 /**
  * Actual Stream constructor wrapped the the main exported function
@@ -912,40 +965,18 @@ Stream.prototype.end = function () {
  */
 
 Stream.prototype.pipe = function (dest) {
-    var self = this;
-
     // stdout and stderr are special case writables that cannot be closed
     var canClose = dest !== process.stdout && dest !== process.stderr;
 
-    var s = self.consume(function (err, x, push, next) {
-        if (err) {
-            self.emit('error', err);
-            return;
-        }
-        if (x === nil) {
-            if (canClose) {
-                dest.end();
-            }
-        }
-        else if (dest.write(x) !== false) {
-            next();
-        }
-    });
-
-    dest.on('drain', onConsumerDrain);
-
-    // Since we don't keep a reference to piped-to streams,
-    // save a callback that will unbind the event handler.
-    this._destructors.push(function () {
-        dest.removeListener('drain', onConsumerDrain);
-    });
-
-    s.resume();
-    return dest;
-
-    function onConsumerDrain() {
-        s.resume();
+    var end;
+    if (canClose) {
+        end = dest.end;
     }
+    else {
+        end = nop;
+    }
+
+    return pipeStream(this, dest, dest.write, end, false);
 };
 
 /**
@@ -2797,26 +2828,20 @@ _.pipeline = function (/*through...*/) {
         start = _(start);
         rest = slice.call(arguments, 1);
     }
+
     var end = rest.reduce(function (src, dest) {
         return src.through(dest);
     }, start);
-    var wrapper = _(function (push, next) {
-        end.pull(function (err, x) {
-            if (err) {
-                wrapper._send(err);
-                next();
-            }
-            else if (x === nil) {
-                wrapper._send(null, nil);
-            }
-            else {
-                wrapper._send(null, x);
-                next();
-            }
-        });
-    });
+
+    var wrapper = _();
+    var _write = wrapper.write;
+    pipeStream(end, wrapper, _write, function () {
+        _write.call(this, nil);
+    }, true);
+
     wrapper.write = function (x) {
         start.write(x);
+        return !this.paused;
     };
     return wrapper;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2840,8 +2840,7 @@ _.pipeline = function (/*through...*/) {
     }, true);
 
     wrapper.write = function (x) {
-        start.write(x);
-        return !this.paused;
+        return start.write(x);
     };
     return wrapper;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -5665,7 +5665,8 @@ exports['pipeline'] = {
         });
 
         test.ok(pipeline.paused, 'pipeline should be paused.');
-        test.ok(!pipeline.write(1), 'pipeline should return false for calls to write since it is paused.');
+        test.strictEqual(pipeline.write(1), false,
+               'pipeline should return false for calls to write since it is paused.');
         test.done();
     }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -5605,59 +5605,69 @@ exports['through'] = {
     }
 };
 
-exports['pipeline'] = function (test) {
-    var parser = through(
-        function (data) {
-            this.queue(JSON.parse(data));
-        },
-        function () {
-            this.queue(null);
-        }
-    );
-    var doubler = _.map(function (x) {
-        return x * 2;
-    });
-    var parseDouble = _.pipeline(parser, doubler);
-    var s = _(function (push, next) {
-        push(null, 1);
-        setTimeout(function () { push(null, 2); }, 10);
-        setTimeout(function () { push(null, 3); }, 20);
-        setTimeout(function () { push(null, 4); }, 30);
-        setTimeout(function () { push(null, _.nil); }, 40);
-    });
-    s.pipe(parseDouble).toArray(function (xs) {
-        test.same(xs, [2,4,6,8]);
-        test.done();
-    });
-};
+exports['pipeline'] = {
+    'usage test': function (test) {
+        var parser = through(
+            function (data) {
+                this.queue(JSON.parse(data));
+            },
+            function () {
+                this.queue(null);
+            }
+        );
+        var doubler = _.map(function (x) {
+            return x * 2;
+        });
+        var parseDouble = _.pipeline(parser, doubler);
+        var s = _(function (push, next) {
+            push(null, 1);
+            setTimeout(function () { push(null, 2); }, 10);
+            setTimeout(function () { push(null, 3); }, 20);
+            setTimeout(function () { push(null, 4); }, 30);
+            setTimeout(function () { push(null, _.nil); }, 40);
+        });
+        s.pipe(parseDouble).toArray(function (xs) {
+            test.same(xs, [2,4,6,8]);
+            test.done();
+        });
+    },
+    'single through function': function (test) {
+        var src = streamify([1,2,3,4]);
+        var through = _.pipeline(function (s) {
+            return s
+                .filter(function (x) {
+                    return x % 2;
+                })
+                .map(function (x) {
+                    return x * 2;
+                })
+                .map(function (x) {
+                    return x + 10;
+                });
+        });
+        src.pipe(through).toArray(function (xs) {
+            test.same(xs, [12, 16]);
+            test.done();
+        });
+    },
+    'no arguments': function (test) {
+        var src = streamify([1,2,3,4]);
+        var through = _.pipeline();
+        src.pipe(through).toArray(function (xs) {
+            test.same(xs, [1,2,3,4]);
+            test.done();
+        });
+    },
+    'should have backpressure': function (test) {
+        test.expect(2);
+        var pipeline = _.pipeline(function (x) {
+            return x;
+        });
 
-exports['pipeline - single through function'] = function (test) {
-    var src = streamify([1,2,3,4]);
-    var through = _.pipeline(function (s) {
-        return s
-            .filter(function (x) {
-                return x % 2;
-            })
-            .map(function (x) {
-                return x * 2;
-            })
-            .map(function (x) {
-                return x + 10;
-            });
-    });
-    src.pipe(through).toArray(function (xs) {
-        test.same(xs, [12, 16]);
+        test.ok(pipeline.paused, 'pipeline should be paused.');
+        test.ok(!pipeline.write(1), 'pipeline should return false for calls to write since it is paused.');
         test.done();
-    });
-};
-
-exports['pipeline - no arguments'] = function (test) {
-    var src = streamify([1,2,3,4]);
-    var through = _.pipeline();
-    src.pipe(through).toArray(function (xs) {
-        test.same(xs, [1,2,3,4]);
-        test.done();
-    });
+    }
 };
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -5659,15 +5659,28 @@ exports['pipeline'] = {
         });
     },
     'should have backpressure': function (test) {
-        test.expect(2);
-        var pipeline = _.pipeline(function (x) {
-            return x;
-        });
+        test.expect(3);
+        var arr = [];
+        var pipeline1 = _.pipeline(_.map(function (x) {
+            return x + 10;
+        }));
 
-        test.ok(pipeline.paused, 'pipeline should be paused.');
-        test.strictEqual(pipeline.write(1), false,
+        test.ok(pipeline1.paused, 'pipeline should be paused.');
+        test.strictEqual(pipeline1.write(1), false,
                'pipeline should return false for calls to write since it is paused.');
-        test.done();
+
+        var pipeline2 = _.pipeline(_.map(function (x) {
+            return x + 10;
+        }));
+
+        _([1, 2, 3])
+            .doto(arr.push.bind(arr))
+            .pipe(pipeline2)
+            .each(arr.push.bind(arr))
+            .done(function () {
+                test.same(arr, [1, 11, 2, 12, 3, 13]);
+                test.done();
+            });
     }
 };
 


### PR DESCRIPTION
Noticed in https://github.com/caolan/highland/issues/371#issuecomment-139092943.

`pipeline` overrides the `write` method but doesn't return anything. For node streams, this has the effect of disabling backpressure, since they do a check for `false === write(...)`. For others, it may have the effect of always enabling backpressure.

We need to return the correct value. This also means supporting the `drain` event, which it didn't before.

My solution was to 
1. construct the result stream via `_()`,
2. override `write` to return `src.write(x)`, and
3. `pipe` `dest` to the result stream.

In the process, I refactored the logic for `pipe` out into a separate function that is used by both `pipeline` and `pipe` (with slightly different behavior).

This was actually more complicated than I thought, so I'd like some eyes on this besides my own.