### PR TITLE
Don't emit 'drain' spuriously & fix deadlock.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -514,10 +514,29 @@ function pipeStream(src, dest, write, end, passAlongErrors) {
 
     function onConsumerDrain() {
         if (resume) {
-            resume();
+            var oldResume = resume;
             resume = null;
+            oldResume();
         }
     }
+}
+
+function generatorPush(stream, write) {
+    if (!write) {
+        write = stream.write;
+    }
+
+    return function (err, x) {
+        if (stream._nil_seen) {
+            throw new Error('Can not write to stream after nil');
+        }
+
+        if (x === nil) {
+            stream._nil_seen = true;
+        }
+
+        write.call(stream, err ? new StreamError(err) : x);
+    };
 }
 
 
@@ -590,17 +609,7 @@ function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
     }
     else if (_.isFunction(xs)) {
         this._generator = xs;
-        this._generator_push = function (err, x) {
-            if (self._nil_seen) {
-                throw new Error('Can not write to stream after nil');
-            }
-
-            if (x === nil) {
-                self._nil_seen = true;
-            }
-
-            self.write(err ? new StreamError(err) : x);
-        };
+        this._generator_push = generatorPush(this);
         this._generator_next = function (s) {
             if (self._nil_seen) {
                 throw new Error('Can not call next after nil');
@@ -2817,31 +2826,44 @@ _.pipeline = function (/*through...*/) {
     if (!arguments.length) {
         return _();
     }
-    var start = arguments[0], rest;
+    var start = arguments[0], rest, startHighland;
     if (!_.isStream(start) && !_.isFunction(start.resume)) {
         // not a Highland stream or Node stream, start with empty stream
         start = _();
+        startHighland = start;
         rest = slice.call(arguments);
     }
     else {
         // got a stream as first argument, co-erce to Highland stream
-        start = _(start);
+        startHighland = _(start);
         rest = slice.call(arguments, 1);
     }
 
     var end = rest.reduce(function (src, dest) {
         return src.through(dest);
-    }, start);
+    }, startHighland);
 
-    var wrapper = _();
-    var _write = wrapper.write;
-    pipeStream(end, wrapper, _write, function () {
-        _write.call(this, nil);
-    }, true);
+    var wrapper = _(function (push, next) {
+        end.pull(function (err, x) {
+            push(err, x);
+            if (x !== nil) {
+                next();
+            }
+        });
+    });
 
     wrapper.write = function (x) {
         return start.write(x);
     };
+
+    wrapper.end = function () {
+        return start.end();
+    };
+
+    start.on('drain', function () {
+        wrapper.emit('drain');
+    });
+
     return wrapper;
 };
 


### PR DESCRIPTION
And of course right after I merge #372, I find out that it doesn't actually work due to synchronous execution of the generator within a call to `next` (2.x behavior).

The `drain` event was also being emitted too often, potentially breaking backpressure in certain cases.

This fixes the "fix" there.