### PR TITLE
Attempt to coerce item in sequence to stream before sending error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2898,56 +2898,33 @@ Stream.prototype.sequence = function () {
         curr.pull(function (err, x) {
             if (err) {
                 push(err);
-                return next();
-            }
-            else if (_.isArray(x)) {
-                if (onOriginalStream()) {
-                    // just send all values from array directly
-                    x.forEach(function (y) {
-                        push(null, y);
-                    });
-                }
-                else {
-                    push(null, x);
-                }
-                return next();
-            }
-            else if (_.isStream(x)) {
-                if (onOriginalStream()) {
-                    // switch to reading new stream
-                    curr = x;
-                    return next();
-                }
-                else {
-                    // sequence only goes 1 level deep
-                    push(null, x);
-                    return next();
-                }
             }
             else if (x === nil) {
                 if (onOriginalStream()) {
-                    push(null, nil);
+                    return push(null, nil);
                 }
                 else {
                     // resume reading from original
                     curr = original;
-                    return next();
                 }
             }
             else {
                 if (onOriginalStream()) {
-                    // we shouldn't be getting non-stream (or array)
-                    // values from the top-level stream
-                    push(new Error(
-                        'Expected Stream, got ' + (typeof x)
-                    ));
-                    return next();
+                    // attempt to cast and switch to reading new stream
+                    try {
+                        curr = _(x);
+                    }
+                    catch (e) {
+                        push(e);
+                    }
                 }
                 else {
+                    // sequence only goes 1 level deep
                     push(null, x);
-                    return next();
                 }
             }
+
+            return next();
         });
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1914,6 +1914,13 @@ exports['sequence - Streams of Streams of Arrays'] = function (test) {
     });
 }
 
+exports['sequence - PromiseStream'] = function (test) {
+    _([Promise.resolve(3)]).sequence().toArray(function (xs) {
+        test.same(xs, [3]);
+        test.done();
+    });
+};
+
 exports['fork'] = function (test) {
     var s = _([1,2,3,4]);
     s.id = 's';
@@ -3485,6 +3492,17 @@ exports['flatMap - GeneratorStream'] = function (test) {
     });
     s.flatMap(f).toArray(function (xs) {
         test.same(xs, [2,4,6,8]);
+        test.done();
+    });
+};
+
+exports['flatMap - map to PromiseStream'] = function (test) {
+    test.expect(1);
+    var f = function (x) {
+        return Promise.resolve(x);
+    };
+    var s = _([1,2,3,4]).flatMap(f).toArray(function (xs) {
+        test.same(xs, [1,2,3,4]);
         test.done();
     });
 };


### PR DESCRIPTION
`highland.js` provides several ways of casting an object into a stream (e.g., array, promise). However, the `sequence` method does not attempt any cast.

This PR updates `sequence` to attempt converting a stream before sending an error. This can be very useful when using `flatMap` with promise returning functions. Currently, if you want to do this, your code may look like:

```js
_([1,2,3,4])
    .map(promiseReturningFunction)
    .flatMap(_);
```

Or,

```js
_([1,2,3,4])
    .flatMap(function (x) {
        return _(promiseReturningFunction(x));
    });
```

This will simplify the boilerplate and allow using `flatMap` directly:

```js
_([1,2,3,4]).flatMap(promiseReturningFunction);
```