### PR TITLE
Upgrade transducers library

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stream-array": "~1.0.1",
     "tape": "~2.4.2",
     "through": "~2.3.4",
-    "transducers-js": "~0.4.135"
+    "transducers-js": "~0.4.174"
   },
   "scripts": {
     "test": "eslint Gruntfile.js lib && nodeunit test/test.js"


### PR DESCRIPTION
Figured that if we're upgrading libraries we may as well use the latest version of `transducers-js` too. Our version of eslint is massively out of date too but when I tried to upgrade that I got errors. I'm not sure how much work it would be fix.