### PR TITLE
Use Set in uniq() When Available In Environment

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -74,6 +74,40 @@ for (var i = 0; i < 1000000; i++) {
     arr1M.push(i);
 }
 
+var uniqArr10K = [];
+for (var i = 0; i < 10000; i++) {
+    var n = (Math.random() * 100) >>> 0;
+    if (n < 20) {
+        // integer
+        uniqArr10K.push(n);
+    } else if (n < 40) {
+        // boolean
+        uniqArr10K.push(n);
+    } else if (n < 60) {
+        // string
+        uniqArr10K.push(n.toString());
+    } else if (n < 80) {
+        // array
+        uniqArr10K.push([n % 3, n % 7, n]);
+    } else {
+        // object
+        uniqArr10K.push({
+            a: 'foo',
+            n: n
+        });
+    }
+}
+
+var uniqArr10KNum = [];
+for (var i = 0; i < 10000; i++) {
+    uniqArr10KNum.push(Math.random() * 100 >>> 0);
+}
+
+var allUniq10k = [];
+for (var i = 0; i < 10000; i++) {
+    allUniq10k.push([true]);
+}
+
 benchmark('.map(square) x 10,000', {
     'underscore': function () { underscore(arr10K).chain().map(square).value(); },
     'lodash': function () { lodash(arr10K).map(square).value(); },
@@ -96,4 +130,22 @@ benchmark('.map(square).filter(isEven).take(100) x 1,000,000', {
     'underscore': function () { underscore(arr1M).chain().map(square).filter(isEven).take(100).value(); },
     'lodash': function () { lodash(arr1M).map(square).filter(isEven).take(100).value(); },
     'highland': function () { highland(arr1M).map(square).filter(isEven).take(100).resume(); }
+});
+
+benchmark('.uniq x 10,000 (heterogenous)', {
+    'underscore': function () { underscore(uniqArr10K).chain().uniq().value(); },
+    'lodash': function () { lodash(uniqArr10K).uniq().value(); },
+    'highland': function () { highland(uniqArr10K).uniq().resume(); }
+});
+
+benchmark('.uniq x 10,000 (numbers)', {
+    'underscore': function () { underscore(uniqArr10KNum).chain().uniq().value(); },
+    'lodash': function () { lodash(uniqArr10KNum).uniq().value(); },
+    'highland': function () { highland(uniqArr10KNum).uniq().resume(); }
+});
+
+benchmark('.uniq x 10,000 (all unique)', {
+    'underscore': function () { underscore(allUniq10k).chain().uniq().value(); },
+    'lodash': function () { lodash(allUniq10k).uniq().value(); },
+    'highland': function () { highland(allUniq10k).uniq().resume(); }
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -2258,6 +2258,28 @@ exposeMethod('uniqBy');
  */
 
 Stream.prototype.uniq = function () {
+    if (!_.isUndefined(_global.Set)) {
+        var uniques = new Set(),
+            size = uniques.size;
+
+        return this.consume(function (err, x, push, next) {
+            if (err) {
+                push(err);
+                next();
+            }
+            else if (x === nil) {
+                push(err, x);
+            }
+            else {
+                uniques.add(x);
+                if (uniques.size > size) {
+                    size = uniques.size;
+                    push(null, x);
+                }
+                next();
+            }
+        });
+    }
     return this.uniqBy(function (a, b) {
         return a === b;
     });

--- a/test/test.js
+++ b/test/test.js
@@ -4356,7 +4356,7 @@ exports['uniqBy'] = function(test) {
     var xs = [ 'blue', 'red', 'red', 'yellow', 'blue', 'red' ]
     _.uniqBy(function(a,b) { return a[1] === b[1] }, xs).toArray(function(xs) {
       test.same(xs, [ 'blue', 'red' ])
-    })
+    });
     test.done();
 };
 
@@ -4366,16 +4366,16 @@ exports['uniqBy - compare error'] = function(test) {
     var s = _.uniqBy(function(a,b) { if (a === "yellow") throw new Error('yellow'); return a === b; }, xs)
     s.pull(function(err, x) {
         test.equal(x, 'blue');
-    })
+    });
     s.pull(function(err, x) {
         test.equal(x, 'red');
-    })
+    });
     s.pull(function(err, x) {
         test.equal(err.message, 'yellow');
-    })
+    });
     s.pull(function(err, x) {
         test.equal(x, _.nil);
-    })
+    });
     test.done();
 };
 
@@ -4383,10 +4383,10 @@ exports['uniqBy - noValueOnError'] = noValueOnErrorTest(_.uniqBy(function(a,b) {
 
 exports['uniq'] = function(test) {
     test.expect(1);
-    var xs = [ 'blue', 'red', 'red', 'yellow', 'blue', 'red' ]
+    var xs = [ 'blue', 'red', 'red', 'yellow', 'blue', 'red' ];
     _.uniq(xs).toArray(function(xs) {
       test.same(xs, [ 'blue', 'red', 'yellow' ])
-    })
+    });
     test.done();
 };
 


### PR DESCRIPTION
A recent discussion on Ramda (ramda/ramda#1512) prompted me to have a look at our `uniq` function so I ported over the benchmarks from there and ran them against our code base. The results were not pretty:

>.uniq x 10,000 (heterogenous)

>underscore  ######################### 61ms
lodash      #### 8ms
highland    ############################################################ 151ms

>.uniq x 10,000 (numbers)

>underscore  ############################## 5ms
lodash      ############ 2ms
highland    ############################################################ 10ms

>.uniq x 10,000 (all unique)

>underscore  #################### 316ms
lodash      # 8ms
highland    ############################################################ 966ms

However, by using `Set` when it is available in the environment the performance can be improved dramatically.

>.uniq x 10,000 (heterogenous)

>underscore  ############################################################ 68ms
lodash      ######## 8ms
highland    ##### 5ms

>.uniq x 10,000 (numbers)

>underscore  ############################################################ 5ms
lodash      ############ 1ms
highland    #################################### 3ms

>.uniq x 10,000 (all unique)

>underscore  ############################################################ 329ms
lodash      ## 8ms
highland    ## 6ms

I normally shy away from this sort of feature sniffing but this is such an easy gain that will benefit all our users running Node 0.12, 4.x and 5.x that I think it's worth it in this case. Thoughts?