### PR TITLE
ensure NaN is passed through in uniq

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2270,6 +2270,12 @@ Stream.prototype.uniq = function () {
             else if (x === nil) {
                 push(err, x);
             }
+            // pass NaN through as Set does not respect strict
+            // equality in this case.
+            else if (x !== x) {
+                push(null, x);
+                next();
+            }
             else {
                 uniques.add(x);
                 if (uniques.size > size) {

--- a/test/test.js
+++ b/test/test.js
@@ -4390,6 +4390,19 @@ exports['uniq'] = function(test) {
     test.done();
 };
 
+exports['uniq - preserves Nan'] = function(test) {
+    test.expect(5);
+    var xs = [ 'blue', 'red', NaN, 'red', 'yellow', 'blue', 'red', NaN ];
+    _.uniq(xs).toArray(function(xs) {
+        test.equal(xs[0], 'blue');
+        test.equal(xs[1], 'red');
+        test.equal(xs[2] !== xs[2], true);
+        test.equal(xs[3], 'yellow');
+        test.equal(xs[4] !== xs[4], true);
+    });
+    test.done();
+};
+
 exports['uniq - noValueOnError'] = noValueOnErrorTest(_.uniq());
 
 exports['zip'] = function (test) {


### PR DESCRIPTION
Fixes the issue mentioned in #395 where the set implementation treats `NaN === `NaN` as `true`.