### PR TITLE
Fixup documentation.

### DIFF
--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -69,7 +69,7 @@
         <a href="http://lodash.com">utility</a>
         <a href="https://github.com/caolan/async">belt</a>,
         Highland manages synchronous and asynchronous code easily, using nothing more than
-        standard JavaScript and Node-like Streams.
+        standard JavaScript and Node-like streams.
         You may be familiar with Promises, EventEmitters and callbacks, but moving
         between them is far from seamless. Thankfully, there exists a deeper abstraction
         which can free our code. By updating the tools we use on Arrays, and applying them
@@ -185,11 +185,11 @@ var nums = _(['1', '2', '3']).map(function (x) {
 });
 
 // calls === 0</code></pre>
-      <p>To get the map iterator to be called, we must pull some data from the Stream. This is called a <strong><em>thunk</em></strong>, and some Highland methods will cause them (e.g., <code>each</code>, <code>done</code>, <code>apply</code>, <code>toArray</code>, <code>pipe</code>, <code>resume</code>).</p>
+      <p>To get the map iterator to be called, we must <em>consume</em> the stream. A number of Highland methods will do so (e.g., <code>each</code>, <code>done</code>, <code>apply</code>, <code>toArray</code>, <code>pipe</code>, <code>resume</code>). A stream may only be consumed once and consuming an already-consumed stream will result in undefined behavior.</p>
       <pre><code class="javascript">nums.each(function (n) { console.log(n); });
 
 // calls === 3</code></pre>
-      <p>Equally, when we tell Highland to map a Stream of filenames to the readFile function, it doesn't actually go and read all the files at once, it let's us decide on how we want to read them:</p>
+      <p>Equally, when we tell Highland to map a Stream of filenames to the `readFile` function, it doesn't actually go and read all the files at once, it let's us decide on how we want to read them:</p>
       <pre><code class="javascript">filenames.map(readFile).series();
 filenames.map(readFile).parallel(10)</code></pre>
 
@@ -214,7 +214,7 @@ source.observe().map(_.log);</code></pre>
 _.map(doubled, mystream)</code></pre>
       <p>By convention, all top-level functions are "curryable", meaning you can partially apply their arguments. In the above example, this could be called as:</p>
       <pre><code class="javascript">_.map(doubled)(mystream);</code></pre>
-      <p>In real-world use, this means you can define the behaviour you'd like before knowing what Stream you'd like to perform it on:</p>
+      <p>In real-world use, this means you can define the behaviour you'd like before knowing what stream you'd like to perform it on:</p>
       <pre><code class="javascript">// partially apply the filter() function to create a new function
 var getBlogposts = _.filter(function (doc) {
     return doc.type === 'blogpost';

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -85,15 +85,15 @@
       <h3 id="browser">Usage in the browser</h3>
       <p>
         Highland can be used both in Node.js and in the browser. When you install the highland package,
-        you will find a <i>dist/highland.js</i> file in the package hierarchy.
+        you will find a <code>dist/highland.js</code> file in the package hierarchy.
         This file has been prepared with browserify in order to bring a browser-ready version of highland.
       </p>
       <p>
-        Simply load this script with a &lt;script&gt; tag, and a <i>highland</i> variable
+      Simply load this script with a <code>&lt;script&gt;</code> tag, and a <code>highland</code> variable
         will be made available in the global javascript scope.
       </p>
       <p>
-        If you prefer using highland under the name <i>_</i> like is done in the examples below,
+        If you prefer using highland under the name <code>_</code> like is done in the examples below,
         you can then simply use:
       </p>
       <pre><code class="javascript">var _ = highland</code></pre>
@@ -165,7 +165,7 @@ counter.each(function (n) {
         });
     });
 };</code></pre>
-      <p>First, we return a new Stream which when read from will read a file (this is called lazy evaluation). When <code>fs.readFile</code> calls its callback, we push the error and data values onto the Stream. Finally, we push <code>_.nil</code> onto the Stream. This is the "end of stream" marker and will tell any consumers of this stream to stop reading.</p>
+      <p>First, we return a new Stream which when read from will read a file (this is called <em>lazy evaluation</em>). When <code>fs.readFile</code> calls its callback, we push the error and data values onto the Stream. Finally, we push <code>_.nil</code> onto the Stream. This is the "end of stream" marker and will tell any consumers of this stream to stop reading.</p>
       <p>Since wrapping a callback is a fairly common thing to do, there is a convenience function:</p>
       <pre><code class="javascript">var getData = _.wrapCallback(fs.readFile);</code></pre>
       <p>Now we have a new asynchronous source, we can run the exact same code from the Array examples on it:</p>
@@ -176,7 +176,7 @@ counter.each(function (n) {
       <pre><code class="javascript">var foo = _($.getJSON('/api/foo'));</code></pre>
 
       <h3 id="laziness">Laziness</h3>
-      <p>When you call <code>map</code> in Highland, it doesn't go off and immediately map over all your data. Rather it defines your intention, and the hard work occurs as you pull data from the Stream. This is 'lazy evaluation' and it's what enables Highland to manage back-pressure and also the sequencing of asynchronous actions, such as reading from a file.</p>
+      <p>When you call <code>map</code> in Highland, it doesn't go off and immediately map over all your data. Rather it defines your intention, and the hard work occurs as you pull data from the Stream. This is <em>lazy evaluation</em> and it's what enables Highland to manage back-pressure and also the sequencing of asynchronous actions, such as reading from a file.</p>
       <pre><code class="javascript">var calls = 0;
 
 var nums = _(['1', '2', '3']).map(function (x) {
@@ -185,7 +185,7 @@ var nums = _(['1', '2', '3']).map(function (x) {
 });
 
 // calls === 0</code></pre>
-      <p>To get the map iterator to be called, we must pull some data from the Stream. This is called a <strong><em>thunk</em></strong>, and some Highland methods will cause them (eg, <code>each</code>, <code>done</code>, <code>apply</code>, <code>toArray</code>, <code>pipe</code>, <code>resume</code>).</p>
+      <p>To get the map iterator to be called, we must pull some data from the Stream. This is called a <strong><em>thunk</em></strong>, and some Highland methods will cause them (e.g., <code>each</code>, <code>done</code>, <code>apply</code>, <code>toArray</code>, <code>pipe</code>, <code>resume</code>).</p>
       <pre><code class="javascript">nums.each(function (n) { console.log(n); });
 
 // calls === 3</code></pre>
@@ -212,7 +212,7 @@ source.observe().map(_.log);</code></pre>
       <pre><code class="javascript">mystream.map(doubled)
 // is equivalent to
 _.map(doubled, mystream)</code></pre>
-      <p>By convention, all top-level functions are 'curryable', meaning you can partially apply their arguments. In the above example, this could be called as:</p>
+      <p>By convention, all top-level functions are "curryable", meaning you can partially apply their arguments. In the above example, this could be called as:</p>
       <pre><code class="javascript">_.map(doubled)(mystream);</code></pre>
       <p>In real-world use, this means you can define the behaviour you'd like before knowing what Stream you'd like to perform it on:</p>
       <pre><code class="javascript">// partially apply the filter() function to create a new function

--- a/lib/index.js
+++ b/lib/index.js
@@ -1323,6 +1323,11 @@ Stream.prototype.write = function (x) {
  * back-pressure. A stream forked to multiple consumers will only pull values
  * from it's source as fast as the slowest consumer can handle them.
  *
+ * *Deprecation warning:* It is currently possible to `fork` a stream after
+ * [consuming](#consume) it (e.g., via a [transform](#Transforms)). This will
+ * no longer be possible in the next major release. If you are going to `fork`
+ * a stream, always call `fork` on it.
+ *
  * @id fork
  * @section Higher-order Streams
  * @name Stream.fork()
@@ -1597,6 +1602,9 @@ Stream.prototype.done = function (f) {
  * value from the source. The transformation function can be replaced with
  * a non-function value for convenience, and it will emit that value
  * for every data event on the source Stream.
+ *
+ * *Deprecation warning:* The use of the convenience non-function argument for
+ * `map` is deprecated and will be removed in the next major version.
  *
  * @id map
  * @section Transforms
@@ -2327,6 +2335,9 @@ exposeMethod('uniq');
  * followed by the second elements of each stream and so on until the shortest
  * input stream is exhausted.
  *
+ * *Note:* This transform will be renamed `zipAll` in the next major version
+ * release.
+ *
  * @id zipAll0
  * @section Higher-order Streams
  * @name Stream.zipAll0()
@@ -2398,6 +2409,9 @@ exposeMethod('zipAll0');
 /**
  * Takes a stream and a `finite` stream of `N` streams
  * and returns a stream of the corresponding `(N+1)`-tuples.
+ *
+ * *Note:* This transform will be renamed `zipEach` in the next major version
+ * release.
  *
  * @id zipAll
  * @section Higher-order Streams
@@ -3284,6 +3298,9 @@ exposeMethod('append');
  * If the iterator throws an error, the reduction stops and the resulting
  * stream will emit that error instead of a value.
  *
+ * *Note:* The order of the `memo` and `iterator` arguments will be flipped in
+ * the next major version release.
+ *
  * @id reduce
  * @section Transforms
  * @name Stream.reduce(memo, iterator)
@@ -3400,6 +3417,9 @@ exposeMethod('collect');
  * If the iterator throws an error, the scan will stop and the stream will
  * emit that error. Any intermediate values that were produced before the
  * error will still be emitted.
+ *
+ * *Note:* The order of the `memo` and `iterator` arguments will be flipped in
+ * the next major version release.
  *
  * @id scan
  * @section Transforms

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,15 +45,13 @@ var Decoder = require('string_decoder').StringDecoder;
  * You can pass a mapping hint as the third argument, which specifies how
  * event arguments are pushed into the stream. If no mapping hint is provided,
  * only the first value emitted with the event to the will be pushed onto the
- * Stream. (NB: in a future version, if more than one argument is passed to the
- * event, an array of all arguments will be pushed to the stream; currently the
- * extra arguments are dropped)
+ * Stream.
  *
- * If mappingHint is a number, an array of that length will be pushed
- * onto the stream, containing exactly that many parameters from the event. If
- * it's an array, it's used as keys to map the arguments into an object which
- * is pushed to the tream. If the mapping hint is a function, it's called with
- * the event arguments, and the returned value is pushed.
+ * If `mappingHint` is a number, an array of that length will be pushed onto
+ * the stream, containing exactly that many parameters from the event. If it's
+ * an array, it's used as keys to map the arguments into an object which is
+ * pushed to the tream. If it is a function, it's called with the event
+ * arguments, and the returned value is pushed.
  *
  * **Promise -** Accepts an ES6 / jQuery style promise and returns a
  * Highland Stream which will emit a single value (or an error).
@@ -70,7 +68,10 @@ var Decoder = require('string_decoder').StringDecoder;
  * @id _(source)
  * @section Stream Objects
  * @name _(source)
- * @param {Array | Function | Readable Stream | Promise | Iterator | Iterable} source - (optional) source to take values from from
+ * @param {Array | Function | Iterator | Iterable | Promise | Readable Stream | String} source - (optional) source to take values from from
+ * @param {EventEmitter | jQuery Element} eventEmitter - (optional) an event emitter. Only valid if `source` is a String.
+ * @param {Array | Function | Number} mappingHint - (optional) how to pass the
+ * arguments to the callback. Only valid if `source` is a String.
  * @api public
  *
  * // from an Array
@@ -350,8 +351,8 @@ _.compose = function (/*functions...*/) {
 };
 
 /**
- * The reversed version of compose. Where arguments are in the order of
- * application.
+ * The reversed version of [compose](#compose). Where arguments are in the
+ * order of application.
  *
  * @id seq
  * @name _.seq(fn1, fn2, ...)
@@ -784,6 +785,8 @@ Stream.prototype._send = function (err, x) {
 /**
  * Pauses the stream. All Highland Streams start in the paused state.
  *
+ * It is unlikely that you will need to manually call this method.
+ *
  * @id pause
  * @section Stream Objects
  * @name Stream.pause()
@@ -874,7 +877,9 @@ Stream.prototype._sendOutgoing = function () {
 
 /**
  * Resumes a paused Stream. This will either read from the Stream's incoming
- * buffer or request more data from an upstream source.
+ * buffer or request more data from an upstream source. Never call this method
+ * on a stream that has been consumed (via a call to [consume](#consume) or any
+ * other transform).
  *
  * @id resume
  * @section Stream Objects
@@ -1590,7 +1595,7 @@ Stream.prototype.done = function (f) {
  * @id map
  * @section Transforms
  * @name Stream.map(f)
- * @param f - the transformation function or value to map to
+ * @param {Function} f - the transformation function or value to map to
  * @api public
  *
  * var doubled = _([1, 2, 3, 4]).map(function (x) {
@@ -1638,7 +1643,7 @@ exposeMethod('map');
  * @id doto
  * @section Transforms
  * @name Stream.doto(f)
- * @param f - the function to apply
+ * @param {Function} f - the function to apply
  * @api public
  *
  * var appended = _([[1], [2], [3], [4]]).doto(function (x) {
@@ -1666,7 +1671,7 @@ exposeMethod('doto');
  * @id tap
  * @section Transforms
  * @name Stream.tap(f)
- * @param f - the function to apply
+ * @param {Function} f - the function to apply
  * @api public
  *
  * _([1, 2, 3]).tap(console.log)
@@ -1916,12 +1921,12 @@ Stream.prototype.pick = function (properties) {
 exposeMethod('pick');
 
 /**
- * Creates a new Stream including only the values which pass a truth test.
+ * Creates a new Stream that includes only the values that pass a truth test.
  *
  * @id filter
  * @section Transforms
  * @name Stream.filter(f)
- * @param f - the truth test function
+ * @param {Function} f - the truth test function
  * @api public
  *
  * var evens = _([1, 2, 3, 4]).filter(function (x) {
@@ -2014,7 +2019,7 @@ exposeMethod('reject');
 
 /**
  * A convenient form of [filter](#filter), which returns the first object from a
- * Stream that passes the provided truth test
+ * Stream that passes the provided truth test.
  *
  * @id find
  * @section Transforms
@@ -2085,7 +2090,7 @@ exposeMethod('findWhere');
  * @id group
  * @section Transforms
  * @name Stream.group(f)
- * @param {Function|String} f - the function or property name on which to group,
+ * @param {Function | String} f - the function or property name on which to group,
  *                              toString() is called on the result of a function.
  * @api public
  *
@@ -2178,15 +2183,18 @@ Stream.prototype.where = function (props) {
 exposeMethod('where');
 
 /**
- * A way to keep only unique objects from a Stream
- * The definition of 'unicity' is given by a Function argument.
+ * Filters out all duplicate values from the stream and keep only the first
+ * occurence of each value, using the provided function to define equality.
  *
  * Note:
- *   - memory: in order to guarantee that each unique item is chosen only once, we need to keep an
- *     internal buffer of all unique values. This may outgrow the available memory if you are not
- *     cautious about the size of your stream and the number of unique objects you may receive on that
- *     stream
- *   - errors: the transformation will emit an error for each comparison that throws an error
+ *
+ * - Memory: In order to guarantee that each unique item is chosen only once,
+ *   we need to keep an internal buffer of all unique values. This may outgrow
+ *   the available memory if you are not cautious about the size of your stream
+ *   and the number of unique objects you may receive on it.
+ * - Errors: The comparison function should never throw an error. However, if
+ *   it does, this transform will emit an error for each all that throws. This
+ *   means that one value may turn into multiple errors.
  *
  * @id uniqBy
  * @section Transforms
@@ -2196,7 +2204,7 @@ exposeMethod('where');
  *
  * var colors = [ 'blue', 'red', 'red', 'yellow', 'blue', 'red' ]
  *
- * _(colors).uniqBy(function(a,b) { return a[1] === b[1] })
+ * _(colors).uniqBy(function(a, b) { return a[1] === b[1]; })
  * // => 'blue'
  * // => 'red'
  *
@@ -2241,8 +2249,12 @@ Stream.prototype.uniqBy = function (compare) {
 exposeMethod('uniqBy');
 
 /**
- * Takes all unique values in a stream.
- * It uses uniqBy internally, using the strict equality === operator to define unicity
+ * Filters out all duplicate values from the stream and keep only the first
+ * occurence of each value, using `===` to define equality.
+ *
+ * Like [uniqBy](#uniqBy), this transform needs to store a buffer containing
+ * all unique values that has been encountered. Be careful about using this
+ * transform on a stream that has many unique values.
  *
  * @id uniq
  * @section Transforms
@@ -2390,7 +2402,8 @@ Stream.prototype.zipAll = function (ys) {
 exposeMethod('zipAll');
 
 /**
- * Takes two Streams and returns a Stream of corresponding pairs.
+ * Takes two Streams and returns a Stream of corresponding pairs. The size of
+ * the resulting stream is the smaller of the two source streams.
  *
  * @id zip
  * @section Higher-order Streams
@@ -2399,6 +2412,8 @@ exposeMethod('zipAll');
  * @api public
  *
  * _(['a', 'b', 'c']).zip([1, 2, 3])  // => ['a', 1], ['b', 2], ['c', 3]
+ *
+ * _(['a', 'b', 'c']).zip(_([1]))  // => ['a', 1]
  */
 
 Stream.prototype.zip = function (ys) {
@@ -2485,12 +2500,12 @@ exposeMethod('batchWithTimeOrCount');
 /**
  * Creates a new Stream with the separator interspersed between the elements of the source.
  *
- * intersperse is effectively the inverse of [splitBy](#splitBy).
+ * `intersperse` is effectively the inverse of [splitBy](#splitBy).
  *
  * @id intersperse
  * @section Transforms
  * @name Stream.intersperse(sep)
- * @param sep - the value to intersperse between the source elements
+ * @param {String} sep - the value to intersperse between the source elements
  * @api public
  *
  * _(['ba', 'a', 'a']).intersperse('n')  // => ba, n, a, n, a
@@ -2525,12 +2540,12 @@ exposeMethod('intersperse');
 /**
  * Splits the source Stream by a separator and emits the pieces in between, much like splitting a string.
  *
- * splitBy is effectively the inverse of [intersperse](#intersperse).
+ * `splitBy` is effectively the inverse of [intersperse](#intersperse).
  *
  * @id splitBy
  * @section Transforms
  * @name Stream.splitBy(sep)
- * @param sep - the separator to split on
+ * @param {String | RegExp} sep - the separator to split on
  * @api public
  *
  * _(['mis', 'si', 's', 'sippi']).splitBy('ss')  // => mi, i, ippi
@@ -2726,14 +2741,24 @@ Stream.prototype.last = function () {
 exposeMethod('last');
 
 /**
- * Collects all values together then emits each value individually but in sorted order.
- * The method for sorting the elements is defined by the comparator function supplied
- * as a parameter.
+ * Collects all values together then emits each value individually in sorted
+ * order. The method for sorting the elements is defined by the comparator
+ * function supplied as a parameter.
+ *
+ * The comparison function takes two arguments `a` and `b` and should return
+ *
+ * - a negative number if `a` should sort before `b`.
+ * - a positive number if `a` should sort after `b`.
+ * - zero if `a` and `b` may sort in any order (i.e., they are equal).
+ *
+ * This function must also define a [partial
+ * order](https://en.wikipedia.org/wiki/Partially_ordered_set). If it does not,
+ * the resulting ordering is undefined.
  *
  * @id sortBy
  * @section Transforms
  * @name Stream.sortBy(f)
- * @param f - the sorting function
+ * @param {Function} f - the comparison function
  * @api public
  *
  * var sorts = _([3, 1, 4, 2]).sortBy(function (a, b) {
@@ -2768,14 +2793,22 @@ exposeMethod('sort');
 
 
 /**
- * Passes the current Stream to a function, returning the result. Can also
- * be used to pipe the current Stream through another Stream. It will always
- * return a Highland Stream (instead of the piped to target directly as in
- * Node.js). Any errors emitted will be propagated as Highland errors.
+ * Transforms a stream using an arbitrary target transform.
+ *
+ * If `target` is a function, this transform passes the current Stream to it,
+ * returning the result.
+ *
+ * If `target` is a [Duplex
+ * Stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex_1),
+ * this transform pipes the current Stream through it. It will always return a
+ * Highland Stream (instead of the piped to target directly as in
+ * [pipe](#pipe)). Any errors emitted will be propagated as Highland errors.
  *
  * @id through
  * @section Higher-order Streams
  * @name Stream.through(target)
+ * @param {Function | Duplex Stream} target - the stream to pipe through or a
+ * function to call.
  * @api public
  *
  * function oddDoubler(s) {
@@ -4176,16 +4209,19 @@ _.log = function () {
  * so you can safely use it as a method without binding (see the second
  * example below).
  *
- * wrapCallback also accepts a mapping hint, which specifies how callback
- * arguments are pushed to the stream. This can be a function, number, or
- * array. See the documentation on [EventEmitter Stream Objects](#Stream Objects)
- * for details.
+ * `wrapCallback` also accepts an optional mapping hint, which specifies how
+ * callback arguments are pushed to the stream. This can be a function, number,
+ * or array. See the documentation on [EventEmitter Stream Objects](#Stream Objects)
+ * for details on the mapping hint. If `mappingHint` is a function, it will be
+ * called with all but the first argument that is passed to the callback. The
+ * first is still assumed to be the error argument.
  *
  * @id wrapCallback
  * @section Utils
  * @name _.wrapCallback(f)
  * @param {Function} f - the node-style function to wrap
- * @param {Function | Number | Array} mappingHint - how to pass the arguments to the callback (optional)
+ * @param {Array | Function | Number} mappingHint - (optional) how to pass the
+ * arguments to the callback
  * @api public
  *
  * var fs = require('fs');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1457,6 +1457,9 @@ exposeMethod('stopOnError');
  * If an error from the Stream reaches the `each` call, it will emit an
  * error event (which will cause it to throw if unhandled).
  *
+ * While `each` consumes the stream, it is possible to chain [done](#done) (and
+ * *only* `done`) after it.
+ *
  * @id each
  * @section Consumption
  * @name Stream.each(f)
@@ -1552,6 +1555,9 @@ Stream.prototype.toArray = function (f) {
  *
  * If an error from the Stream reaches the `done` call, it will emit an
  * error event (which will cause it to throw if unhandled).
+ *
+ * As a special case, it is possible to chain `done` after a call to
+ * [each](#each) even though both methods consume the stream.
  *
  * @id done
  * @section Consumption

--- a/lib/index.js
+++ b/lib/index.js
@@ -1740,7 +1740,7 @@ exposeMethod('ratelimit');
  * Creates a new Stream of values by applying each item in a Stream to an
  * iterator function which must return a (possibly empty) Stream. Each item on
  * these result Streams are then emitted on a single output Stream.
- * 
+ *
  * This transform is functionally equivalent to `.map(f).sequence()`.
  *
  * @id flatMap
@@ -3625,7 +3625,7 @@ exposeMethod('concat');
  * @api public
  *
  * var readFile = _.wrapCallback(fs.readFile);
- * 
+ *
  * var txt = _(['foo.txt', 'bar.txt']).map(readFile)
  * var md = _(['baz.md']).map(readFile)
  *
@@ -3758,7 +3758,7 @@ exposeMethod('merge');
  * @api public
  *
  * var readFile = _.wrapCallback(fs.readFile);
- * 
+ *
  * var txt = _(['foo.txt', 'bar.txt']).flatMap(readFile)
  * var md = _(['baz.md']).flatMap(readFile)
  * var js = _(['bosh.js']).flatMap(readFile)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1994,14 +1994,7 @@ exposeMethod('filter');
  * @param {Function} f - the truth test function which returns a Stream
  * @api public
  *
- * function checkExists(file) {
- *     return _(function (push, next) {
- *         fs.exists(file, function (exists) {
- *             push(null, exists);
- *             push(null, _.nil);
- *         });
- *     });
- * }
+ * var checkExists = _.wrapCallback(fs.access);
  *
  * filenames.flatFilter(checkExists)
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -1983,7 +1983,15 @@ exposeMethod('filter');
  * @param {Function} f - the truth test function which returns a Stream
  * @api public
  *
- * var checkExists = _.wrapCallback(fs.exists);
+ * function checkExists(file) {
+ *     return _(function (push, next) {
+ *         fs.exists(file, function (exists) {
+ *             push(null, exists);
+ *             push(null, _.nil);
+ *         });
+ *     });
+ * }
+ *
  * filenames.flatFilter(checkExists)
  */
 
@@ -4215,12 +4223,15 @@ _.log = function () {
  * so you can safely use it as a method without binding (see the second
  * example below).
  *
- * `wrapCallback` also accepts an optional mapping hint, which specifies how
- * callback arguments are pushed to the stream. This can be a function, number,
- * or array. See the documentation on [EventEmitter Stream Objects](#Stream Objects)
- * for details on the mapping hint. If `mappingHint` is a function, it will be
- * called with all but the first argument that is passed to the callback. The
- * first is still assumed to be the error argument.
+ * `wrapCallback` also accepts an optional `mappingHint`, which specifies how
+ * callback arguments are pushed to the stream. This can be used to handle
+ * non-standard callback protocols that pass back more than one value.
+ *
+ * `mappingHint` can be a function, number, or array. See the documentation on
+ * [EventEmitter Stream Objects](#Stream Objects) for details on the mapping
+ * hint. If `mappingHint` is a function, it will be called with all but the
+ * first argument that is passed to the callback. The first is still assumed to
+ * be the error argument.
  *
  * @id wrapCallback
  * @section Utils

--- a/lib/index.js
+++ b/lib/index.js
@@ -1452,7 +1452,7 @@ exposeMethod('stopOnError');
 
 /**
  * Iterates over every value from the Stream, calling the iterator function
- * on each of them. This function causes a **thunk**.
+ * on each of them. This method consumes the Stream.
  *
  * If an error from the Stream reaches the `each` call, it will emit an
  * error event (which will cause it to throw if unhandled).
@@ -1488,7 +1488,7 @@ Stream.prototype.each = function (f) {
 exposeMethod('each');
 
 /**
- * Applies all values from a Stream as arguments to a function. This function causes a **thunk**.
+ * Applies all values from a Stream as arguments to a function. This method consumes the stream.
  * `f` will always be called when the `nil` token is encountered, even when the stream is empty.
  *
  * @id apply
@@ -1518,7 +1518,7 @@ exposeMethod('apply');
 
 /**
  * Collects all values from a Stream into an Array and calls a function with
- * the result. This function causes a **thunk**.
+ * the result. This method consumes the stream.
  *
  * If an error from the Stream reaches the `toArray` call, it will emit an
  * error event (which will cause it to throw if unhandled).
@@ -1547,7 +1547,7 @@ Stream.prototype.toArray = function (f) {
 };
 
 /**
- * Calls a function once the Stream has ended. This function causes a **thunk**.
+ * Calls a function once the Stream has ended. This method consumes the stream.
  * If the Stream has already ended, the function is called immediately.
  *
  * If an error from the Stream reaches the `done` call, it will emit an
@@ -2183,7 +2183,7 @@ Stream.prototype.where = function (props) {
 exposeMethod('where');
 
 /**
- * Filters out all duplicate values from the stream and keep only the first
+ * Filters out all duplicate values from the stream and keeps only the first
  * occurence of each value, using the provided function to define equality.
  *
  * Note:
@@ -2249,7 +2249,7 @@ Stream.prototype.uniqBy = function (compare) {
 exposeMethod('uniqBy');
 
 /**
- * Filters out all duplicate values from the stream and keep only the first
+ * Filters out all duplicate values from the stream and keeps only the first
  * occurence of each value, using `===` to define equality.
  *
  * Like [uniqBy](#uniqBy), this transform needs to store a buffer containing
@@ -3343,7 +3343,7 @@ exposeMethod('reduce1');
 /**
  * Groups all values into an Array and passes down the stream as a single
  * data event. This is a bit like doing [toArray](#toArray), but instead
- * of accepting a callback and causing a *thunk*, it passes the value on.
+ * of accepting a callback and consuming the stream, it passes the value on.
  *
  * @id collect
  * @section Transforms

--- a/lib/index.js
+++ b/lib/index.js
@@ -1747,6 +1747,7 @@ exposeMethod('ratelimit');
  * @param {Function} f - the iterator function
  * @api public
  *
+ * var readFile = _.wrapCallback(fs.readFile);
  * filenames.flatMap(readFile)
  */
 
@@ -2964,6 +2965,7 @@ _.pipeline = function (/*through...*/) {
  * nums.sequence()  // => 1, 2, 3, 4, 5, 6
  *
  * // using sequence to read from files in series
+ * var readFile = _.wrapCallback(fs.readFile);
  * filenames.map(readFile).sequence()
  */
 
@@ -3041,6 +3043,7 @@ exposeMethod('sequence');
  * @name Stream.series()
  * @api public
  *
+ * var readFile = _.wrapCallback(fs.readFile);
  * filenames.map(readFile).series()
  */
 
@@ -3619,6 +3622,8 @@ exposeMethod('concat');
  * @name Stream.merge()
  * @api public
  *
+ * var readFile = _.wrapCallback(fs.readFile);
+ * 
  * var txt = _(['foo.txt', 'bar.txt']).map(readFile)
  * var md = _(['baz.md']).map(readFile)
  *
@@ -3750,6 +3755,8 @@ exposeMethod('merge');
  * @param {Number} n - the maximum number of streams to run in parallel
  * @api public
  *
+ * var readFile = _.wrapCallback(fs.readFile);
+ * 
  * var txt = _(['foo.txt', 'bar.txt']).flatMap(readFile)
  * var md = _(['baz.md']).flatMap(readFile)
  * var js = _(['bosh.js']).flatMap(readFile)
@@ -3821,7 +3828,8 @@ exposeMethod('mergeWithLimit');
  *
  * _(['foo', 'bar']).invoke('toUpperCase', [])  // => FOO, BAR
  *
- * filenames.map(readFile).sequence().invoke('toString', ['utf8']);
+ * var readFile = _.wrapCallback(fs.readFile);
+ * filenames.flatMap(readFile).invoke('toString', ['utf8']);
  */
 
 Stream.prototype.invoke = function (method, args) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1740,6 +1740,8 @@ exposeMethod('ratelimit');
  * Creates a new Stream of values by applying each item in a Stream to an
  * iterator function which must return a (possibly empty) Stream. Each item on
  * these result Streams are then emitted on a single output Stream.
+ * 
+ * This transform is functionally equivalent to `.map(f).sequence()`.
  *
  * @id flatMap
  * @section Higher-order Streams


### PR DESCRIPTION
I only meant to update `uniq` to stop saying that it's implemented via `uniqBy` but ended up doing a pass over the entire documentation...

Most of the changes are adding formatting and type annotations for arguments, though I've clarified the wording in certain cases.

I also have a question. The docs mentions this at one point

> To get the map iterator to be called, we must pull some data from the Stream. This is called a ***thunk***, and some Highland methods will cause them (eg, `each`, `done`, `apply`, `toArray`, `pipe`, `resume`).

My familiarity with the term `thunk` is in this context: https://en.wikipedia.org/wiki/Thunk. Basically, it's a chunk of code, which is not the way it's being used here. Is this usage of the term common?

