### PR TITLE
use minified version for browser tests

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -34,15 +34,8 @@ To run the linter and nodeunit tests in Node.js, use the grunt task:
 
 To run tests in a browser, first build the browser-test bundle.
 
-    grunt browserify:test-browser
+    grunt build-browser-tests
     # now visit test/browser.html in your browser
-
-The package.json has also been set-up to run tests with testling, localy this
-will use whatever headless browser it can find on your system.
-
-    npm install -g testling
-    testling
-
 
 Editing docs
 ------------

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,9 @@ module.exports = function (grunt) {
             'test-browser': {
                 files: {
                     'test/bundle.js': ['test/browser.js']
+                },
+                options: {
+                    exclude: 'lib/**'
                 }
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,6 +139,7 @@ module.exports = function (grunt) {
         'gh-pages'
     ]);
 
+    grunt.registerTask('build-browser-tests', ['build', 'browserify:test-browser']);
     grunt.registerTask('test', ['eslint:all', 'nodeunit:all']);
     grunt.registerTask('build', ['browserify:main', 'uglify:main', 'docs']);
     grunt.registerTask('default', ['build']);

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,17 +148,11 @@ _.isArray = Array.isArray || function (x) {
     return Object.prototype.toString.call(x) === '[object Array]';
 };
 
-// setImmediate implementation with browser and older node fallbacks
+// setImmediate browser fallback
 if (typeof setImmediate === 'undefined') {
-    if (typeof process === 'undefined' || !(process.nextTick)) {
-        _.setImmediate = function (fn) {
-            setTimeout(fn, 0);
-        };
-    }
-    else {
-        // use nextTick on old node versions
-        _.setImmediate = process.nextTick;
-    }
+    _.setImmediate = function (fn) {
+        setTimeout(fn, 0);
+    };
 }
 // check no process.stdout to detect browserify
 else if (typeof process === 'undefined' || !(process.stdout)) {
@@ -170,7 +164,6 @@ else if (typeof process === 'undefined' || !(process.stdout)) {
 else {
     _.setImmediate = setImmediate;
 }
-
 
 /**
  * The end of stream marker. This is sent along the data channel of a Stream

--- a/test/browser.html
+++ b/test/browser.html
@@ -1,24 +1,20 @@
 <html>
 <head>
-<title>Highland Browser Tests</title>
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<link rel="stylesheet" href="../node_modules/nodeunit/share/nodeunit.css" />
+    <title>Highland Browser Tests</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="../node_modules/nodeunit/share/nodeunit.css"/>
 </head>
 
 <body>
+<script src="../dist/highland.min.js"></script>
 <script src="./bundle.js"></script>
 <script>
-if (!window.nodeunit) {
-    document.write('<h1>ERROR: ./bundle.js not found</h1>');
-    document.write('<p>Try running <kbd>grunt browserify:test-browser</kbd></p>');
-}
+    if (!window.nodeunit) {
+        document.write('<h1>ERROR: ./bundle.js not found</h1>');
+        document.write('<p>Try running <kbd>grunt browserify:test-browser</kbd></p>');
+    }
 </script>
 
-<h3>TODO</h3>
-<ul>
-<li>test <kbd>dist/highland.js</kbd> instead of a different bundle</li>
-</ul>
-
-<hr />
+<hr/>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-var EventEmitter = require('events').EventEmitter,
+var _, EventEmitter = require('events').EventEmitter,
     through = require('through'),
     sinon = require('sinon'),
     Stream = require('stream'),
@@ -6,8 +6,13 @@ var EventEmitter = require('events').EventEmitter,
     concat = require('concat-stream'),
     RSVP = require('rsvp'),
     Promise = RSVP.Promise,
-    transducers = require('transducers-js'),
+    transducers = require('transducers-js');
+
+if (global.highland != null) {
+    _ = global.highland;
+} else {
     _ = require('../lib/index');
+}
 
 // Use setTimeout. The default is process.nextTick, which sinon doesn't
 // handle.


### PR DESCRIPTION
As discussed in #392, including removing the `nextTick` fallback.