### PR TITLE
use containers for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "0.10"
   - "0.12"


### PR DESCRIPTION
The build error in #408 might have been transient but I did see a message in there that said we are using the legacy infrastructure for Travis builds and how to upgrade:

https://docs.travis-ci.com/user/workers/container-based-infrastructure/