### PR TITLE
Add deprecation warnings.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@
 
 
 var inherits = require('util').inherits;
+var deprecate = require('util-deprecate');
 var EventEmitter = require('events').EventEmitter;
 var Decoder = require('string_decoder').StringDecoder;
 
@@ -1244,6 +1245,7 @@ Stream.prototype.consume = function (f) {
         }
     };
     self._addConsumer(s);
+    self._already_consumed = true;
     return s;
 };
 exposeMethod('consume');
@@ -1349,7 +1351,17 @@ Stream.prototype.write = function (x) {
  * zs.resume();
  */
 
+// Hack our way around the fact that util.deprecate is all-or-nothing for a
+// function.
+var warnForkAfterConsume = deprecate(function () {
+}, 'Highland: Calling Stream.fork() on a stream that has already been consumed is deprecated. Always call fork() on a stream that is meant to be forked.');
+
 Stream.prototype.fork = function () {
+    if (this._already_consumed) {
+        // Trigger deprecation warning.
+        warnForkAfterConsume();
+    }
+
     var s = new Stream();
     s.id = 'fork:' + s.id;
     s.source = this;
@@ -1620,12 +1632,16 @@ Stream.prototype.done = function (f) {
  * var doubled = _([1, 2, 3, 4]).map(function (x) {
  *     return x * 2;
  * });
- *
- * _([1, 2, 3]).map('hi')  // => 'hi', 'hi', 'hi'
  */
+
+// Hack our way around the fact that util.deprecate is all-or-nothing for a
+// function.
+var warnMapWithValue = deprecate(function() {
+}, 'Highland: Calling Stream.map() with a non-function argument is deprecated.');
 
 Stream.prototype.map = function (f) {
     if (!_.isFunction(f)) {
+        warnMapWithValue();
         var val = f;
         f = function () {
             return val;

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   },
   "scripts": {
     "test": "eslint Gruntfile.js lib && nodeunit test/test.js"
+  },
+  "dependencies": {
+    "util-deprecate": "^1.0.2"
   }
 }


### PR DESCRIPTION
Add deprecation warnings, as suggested by @quarterto in #404. This temporarily pulls in [util-deprecate](https://www.npmjs.com/package/util-deprecate) as a non-dev-dependency. `util.deprecate` doesn't seem to work in the browser (something about too much recursion).