### PR TITLE
Verify that the argument to parallel is valid.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3143,6 +3143,14 @@ Stream.prototype.parallel = function (n) {
     var ended = false;
     var reading_source = false;
 
+    if (typeof n !== 'number') {
+        throw new Error('Must specify a number to parallel().');
+    }
+
+    if (n <= 0) {
+        throw new Error('The parallelism factor must be positive');
+    }
+
     return _(function (push, next) {
         if (running.length < n && !ended && !reading_source) {
             // get another stream if not already waiting for one

--- a/test/test.js
+++ b/test/test.js
@@ -5317,6 +5317,22 @@ exports['parallel - parallel should not drop data if paused (issue #328)'] = fun
         });
 };
 
+exports['parallel - should throw if arg is not a number (issue #420)'] = function (test) {
+    test.expect(1);
+    test.throws(function () {
+        _([]).parallel();
+    });
+    test.done();
+};
+
+exports['parallel - should throw if arg is not positive'] = function (test) {
+    test.expect(1);
+    test.throws(function () {
+        _([]).parallel(-1);
+    });
+    test.done();
+};
+
 exports['throttle'] = {
     setUp: function (callback) {
         this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
Checks that the argument to `parallel` is a number and is `> 0`.