### PR TITLE
make streams duck-type as readable Node streams

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,6 +134,7 @@ function __(StreamCtor) {
         if (_.isUndefined(xs)) {
             // nothing else to do
             s = new StreamCtor();
+            s.writable = true;
         }
         else if (_.isStream(xs)) {
             if (!(xs instanceof StreamCtor)) { // different subclass or version
@@ -157,7 +158,11 @@ function __(StreamCtor) {
             // check to see if we have a readable stream
             if (_.isFunction(xs.on) && _.isFunction(xs.pipe)) {
                 s = new StreamCtor();
+                s.writable = true;
                 pipeReadable(xs, s);
+                // s has to be writable so that the pipe works
+                // return a non-writable stream
+                return s.map(function (x) { return x; });
             }
             else if (_.isFunction(xs.then)) {
                 // probably a promise
@@ -700,8 +705,10 @@ function Stream(generator) {
         }
     };
 
-    // Old-style node Stream.pipe() checks for this
-    self.writable = true;
+    // Old-style node Stream.pipe() checks for writable, and gulp checks for
+    // readable. Discussion at https://github.com/caolan/highland/pull/438.
+    self.readable = true;
+    self.writable = false;
 
     self.on('newListener', function (ev) {
         if (ev === 'data') {
@@ -859,9 +866,16 @@ Stream.prototype._send = function (token) {
 
     if (_._isStreamError(token)) {
         err = token.error;
+        this.readable = false;
     }
     else {
         x = token;
+    }
+
+    if (x === nil) {
+        // Per https://nodejs.org/docs/v0.8.28/api/stream.html#stream_stream_readable
+        // streams stop being readable when they end or are destroyed
+        this.readable = false;
     }
 
     if (this._request) {
@@ -1077,12 +1091,19 @@ addMethod('destroy', function () {
         return;
     }
 
+    this.readable = this.writable = false;
+
     this.end();
     this._onEnd();
 });
 
 Stream.prototype._writeOutgoing = function _writeOutgoing(token) {
     //console.log('_writeOutgoing', token, this.id);
+    if (token === nil || _._isStreamError(token)) {
+        // Per https://nodejs.org/docs/v0.8.28/api/stream.html#stream_stream_writable
+        // writable should turn false after end is called or an error occurs
+        this.writable = false;
+    }
     if (this.paused) {
         this._outgoing.enqueue(token);
     }
@@ -1378,6 +1399,7 @@ addMethod('fork', function () {
 addMethod('observe', function () {
     var s = this.create();
     s.id = 'observe:' + s.id;
+    s.writable = false;
 
     s.onDestroy(this._removeObserver.bind(this, s));
 
@@ -2850,11 +2872,14 @@ addToplevelMethod('pipeline', function (/*through...*/) {
         });
     });
 
+    wrapper.writable = true;
+
     wrapper.write = function (x) {
         return start.write(x);
     };
 
     wrapper.end = function () {
+        wrapper.writable = false;
         return start.end();
     };
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "grunt-npm": "0.0.2",
     "handlebars": "~4.0.5",
     "nodeunit": "~0.9.1",
+    "orchestrator": "^0.3.7",
     "rsvp": "~3.1.0",
     "scrawl": "0.0.5",
     "sinon": "~1.15.4",


### PR DESCRIPTION
This supports returning Highland streams from gulp tasks; gulp will wait for them to complete exactly like it does with Node streams.