### PR TITLE
Make pipe behave more like Readable#pipe. Fixes #449.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -961,7 +961,7 @@ Stream.prototype.end = function () {
  *
  * - `end` - Ends the destination when this stream ends. Default: `true`. This
  *   option has no effect if the destination is either `process.stdout` or
- *   `process.stderr`. Those two streams are never neded.
+ *   `process.stderr`. Those two streams are never ended.
  *
  * Like [Readable#pipe](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options),
  * this function will throw errors if there is no `error` handler installed on

--- a/lib/index.js
+++ b/lib/index.js
@@ -506,6 +506,8 @@ function pipeStream(src, dest, write, end, passAlongErrors) {
         dest.removeListener('drain', onConsumerDrain);
     });
 
+    dest.emit('pipe', src);
+
     s.resume();
     return dest;
 
@@ -955,17 +957,24 @@ Stream.prototype.end = function () {
  * automatically managing flow so that the destination is not overwhelmed
  * by a fast source.
  *
- * This function returns the destination so you can chain together pipe calls.
+ * Users may optionally pass an object that may contain any of these fields:
+ *
+ * - `end` - Ends the destination when this stream ends. Default: `true`. This
+ *   option has no effect if the destination is either `process.stdout` or
+ *   `process.stderr`. Those two streams are never neded.
  *
  * Like [Readable#pipe](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options),
  * this function will throw errors if there is no `error` handler installed on
  * the stream. Use [through](#through) if you are piping to another Highland
  * stream and want errors as well as values to be propagated.
  *
+ * This function returns the destination so you can chain together pipe calls.
+ *
  * @id pipe
  * @section Consumption
- * @name Stream.pipe(dest)
+ * @name Stream.pipe(dest, options)
  * @param {Writable Stream} dest - the destination to write all data to
+ * @param {Object} options - (optional) pipe options.
  * @api public
  *
  * var source = _(generator);
@@ -976,9 +985,11 @@ Stream.prototype.end = function () {
  * source.pipe(through).pipe(dest);
  */
 
-Stream.prototype.pipe = function (dest) {
+Stream.prototype.pipe = function (dest, options) {
+    options = options || {};
+
     // stdout and stderr are special case writables that cannot be closed
-    var canClose = dest !== process.stdout && dest !== process.stderr;
+    var canClose = dest !== process.stdout && dest !== process.stderr && options.end !== false;
 
     var end;
     if (canClose) {


### PR DESCRIPTION
Pipe didn't support all of the behaviors of `Readable#pipe`, which results in annoying bugs. This brings it more in line.
1. `pipe` now emits the `pipe` event on the destination when piping.
2. `pipe` has an optional pipe options argument that allows users to
  choose to not end the destination when the source ends.

The second argument to `pipe` is optional, and generally we don't put optional arguments in stream transforms. However, since `pipe` is meant for interop, there's a bigger win in making it mimic the node stream interface.