### PR TITLE
mergeWithLimit should not throw error if source has error. Fixes #475.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This file does not aim to be comprehensive (you have git history for that),
 rather it lists changes that might impact your own code as a consumer of
 this library.
 
+2.7.4
+-----
+### Bugfix
+* `mergeOnError` no longer causes an `// Unhandled 'error' event` error when one
+  of its sources emits an error.
+
 2.7.3
 -----
 ### Bugfix

--- a/lib/index.js
+++ b/lib/index.js
@@ -3873,6 +3873,7 @@ Stream.prototype.mergeWithLimit = function (n){
     if (typeof n !== 'number' || n < 1) {
         throw new Error('mergeWithLimit expects a positive number, but got: ' + n);
     }
+
     if (n === Infinity) {
         return this.merge();
     }
@@ -3890,7 +3891,7 @@ Stream.prototype.mergeWithLimit = function (n){
                 processCount++;
                 push(err, x);
                 // console.log('start', x.id);
-                x.once('end', function(){
+                x._destructors.push(function(){
                     processCount--;
                     // console.log('end', x.id);
                     if (waiting) {

--- a/test/test.js
+++ b/test/test.js
@@ -3329,6 +3329,22 @@ exports['mergeWithLimit'] = {
         });
         this.clock.tick(100);
     },
+    'correctly forwards errors - issue #475': function (test) {
+        test.expect(2);
+        var s1 = _([1, 2, 3, 4]);
+        var s2 = _(function (push, next) {
+            push(new Error('error'))
+            push(null, _.nil);
+        });
+        _([s1, s2]).mergeWithLimit(2)
+            .errors(function (err) {
+                test.equal(err.message, 'error');
+            })
+            .toArray(function (xs) {
+                test.same(xs, [1, 2, 3, 4]);
+                test.done();
+            });
+    },
     'noValueOnError': noValueOnErrorTest(_.mergeWithLimit(1)),
 };
 


### PR DESCRIPTION
We used to get a

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
```

error when a source emits errors due to listening for the `end` event without doing so for the `error` event.