### PR TITLE
Clarify the error throwing behavior of certain consumption methods.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1529,8 +1529,9 @@ exposeMethod('stopOnError');
  * Iterates over every value from the Stream, calling the iterator function
  * on each of them. This method consumes the Stream.
  *
- * If an error from the Stream reaches the `each` call, it will emit an
- * error event (which will cause it to throw if unhandled).
+ * If an error from the Stream reaches this call, it will emit an `error` event
+ * (i.e., it will call `emit('error')` on the stream being consumed).  This
+ * event will cause an error to be thrown if unhandled.
  *
  * While `each` consumes the stream, it is possible to chain [done](#done) (and
  * *only* `done`) after it.
@@ -1598,8 +1599,9 @@ exposeMethod('apply');
  * Collects all values from a Stream into an Array and calls a function with
  * the result. This method consumes the stream.
  *
- * If an error from the Stream reaches the `toArray` call, it will emit an
- * error event (which will cause it to throw if unhandled).
+ * If an error from the Stream reaches this call, it will emit an `error` event
+ * (i.e., it will call `emit('error')` on the stream being consumed).  This
+ * event will cause an error to be thrown if unhandled.
  *
  * @id toArray
  * @section Consumption
@@ -1628,8 +1630,9 @@ Stream.prototype.toArray = function (f) {
  * Calls a function once the Stream has ended. This method consumes the stream.
  * If the Stream has already ended, the function is called immediately.
  *
- * If an error from the Stream reaches the `done` call, it will emit an
- * error event (which will cause it to throw if unhandled).
+ * If an error from the Stream reaches this call, it will emit an `error` event
+ * (i.e., it will call `emit('error')` on the stream being consumed).  This
+ * event will cause an error to be thrown if unhandled.
  *
  * As a special case, it is possible to chain `done` after a call to
  * [each](#each) even though both methods consume the stream.


### PR DESCRIPTION
The usage of the word "emit" in certain consumption methods can be confusing. See the thread staring at https://github.com/caolan/highland/issues/356#issuecomment-212063175.

@hflw, is this better?