### PR TITLE
Added complete method, just like toArray but passes first error if occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ this library.
 ### New additions
 * `complete`: Like `toArray`, but passes first error in first parameter, and the
   result array as the second if no error was thrown.
+  [#488](https://github.com/caolan/highland/pull/488).
 
 2.7.4
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ this library.
 * `complete`: Like `toArray`, but passes first error in first parameter, and the
   result array as the second if no error was thrown.
   [#488](https://github.com/caolan/highland/pull/488).
+  Fixed [#484](https://github.com/caolan/highland/issues/484).
 
 2.7.4
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ this library.
   [#479](https://github.com/caolan/highland/pull/479).
   Fixes [#478](https://github.com/caolan/highland/issues/478).
 
+### New additions
+* `complete`: Like `toArray`, but passes first error in first parameter, and the
+  result array as the second if no error was thrown.
+
 2.7.4
 -----
 ### Bugfix

--- a/lib/index.js
+++ b/lib/index.js
@@ -1676,7 +1676,16 @@ Stream.prototype.toArray = function (f) {
  */
 
 Stream.prototype.complete = function (f) {
-    return this.collect().pull(f);
+    var s = this.collect()
+        .stopOnError(function (err, push) {
+            push(err);
+        });
+    s.pull(function (err, x) {
+        s.pull(function () {
+            f(err, x);
+        });
+    });
+    return null;
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -1658,6 +1658,28 @@ Stream.prototype.toArray = function (f) {
 };
 
 /**
+ * Collects all values from a Stream and calls a function with
+ * the first error and result. This method consumes the stream.
+ *
+ * If an error from the Stream reaches this call, it will be passed into the
+ * callback function as the first parameter.
+ *
+ * @id complete
+ * @section Consumption
+ * @name Stream.complete(f)
+ * @param {Function} f - the callback
+ * @api public
+ *
+ * _([1, 2, 3, 4]).complete(function (err, x) {
+ *     // parameter x will be [1,2,3,4]
+ * });
+ */
+
+Stream.prototype.complete = function (f) {
+    return this.collect().pull(f);
+};
+
+/**
  * Calls a function once the Stream has ended. This method consumes the stream.
  * If the Stream has already ended, the function is called immediately.
  *

--- a/test/test.js
+++ b/test/test.js
@@ -1424,6 +1424,50 @@ exports['each - throw error if consumed'] = function (test) {
     test.done();
 };
 
+exports['complete'] = function (test) {
+    _([1,2,3,4]).complete(function (err, xs) {
+        test.same(xs, [1,2,3,4]);
+        test.done();
+    });
+};
+
+exports['complete - errors'] = function (test) {
+    var e = new Error('one');
+    var s = _(function (push, next) {
+        push(null, 1);
+        push(e);
+        push(null, 2);
+        push(null, _.nil);
+    }).complete(function (err, xs) {
+        test.same(xs, undefined);
+        test.same(err, e);
+        test.done();
+    });
+};
+
+exports['complete - ArrayStream'] = function (test) {
+    _([1,2,3,4]).complete(function (err, xs) {
+        test.same(xs, [1,2,3,4]);
+        test.done();
+    });
+};
+
+exports['complete - GeneratorStream'] = function (test) {
+    var s = _(function (push, next) {
+        setTimeout(function () {
+            push(null, 1);
+            push(null, 2);
+            push(null, 3);
+            push(null, 4);
+            push(null, _.nil);
+        }, 10);
+    });
+    s.complete(function (err, xs) {
+        test.same(xs, [1,2,3,4]);
+        test.done();
+    });
+};
+
 exports['done'] = function (test) {
     test.expect(3);
 


### PR DESCRIPTION
This request is related to #484. I wanted to have way of consuming the stream and calling a standard callback which takes an error if occurred as the first parameter.