### PR TITLE
Added toCallback method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ this library.
   [#479](https://github.com/caolan/highland/pull/479).
   Fixes [#478](https://github.com/caolan/highland/issues/478).
 
+### New additions
+* `toCallback`: method for returning the result of a stream to a
+  nodejs-style callback function.
+  [#493](https://github.com/caolan/highland/pull/493)
+  Fixes [#484](https://github.com/caolan/highland/issues/484)
+
 ### Improvements
 * A Highland Stream that wraps a bluebird promise can now handle bluebird
   cancellation. When the promise is cancelled the wrapper stream is empty.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1741,24 +1741,39 @@ Stream.prototype.done = function (f) {
  */
 
 Stream.prototype.toCallback = function (cb) {
-    var encounteredError = false;
-    return this.stopOnError(function(err) {
-        encounteredError = true;
-        cb(err);
-    }).take(2).toArray(function (arr) {
-        if (encounteredError) {
-            return;
+    var value;
+    var hasValue = false; // In case an emitted value === null or === undefined.
+
+    this.consume(function (err, x, push, next) {
+        if (err) {
+            push(null, nil);
+            if (hasValue) {
+                cb(new Error('toCallback called on stream emitting multiple values'));
+            }
+            else {
+                cb(err);
+            }
         }
-        if (arr.length > 1) {
-            throw new Error('toCallback called on stream emitting multiple values');
-        }
-        else if (arr[0]) {
-            cb(null, arr[0]);
+        else if (x === nil) {
+            if (hasValue) {
+              cb(null, value);
+            }
+            else {
+              cb();
+            }
         }
         else {
-            cb();
+            if (hasValue) {
+                push(null, nil);
+                cb(new Error('toCallback called on stream emitting multiple values'));
+            }
+            else {
+                value = x;
+                hasValue = true;
+                next();
+            }
         }
-    });
+    }).resume();
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -1719,6 +1719,49 @@ Stream.prototype.done = function (f) {
 };
 
 /**
+ * Returns the result of a stream to a nodejs-style callback function.
+ *
+ * If the stream contains a single value, it will call `cb`
+ * with the single item emitted by the stream (if present).
+ * If the stream is empty, `cb` will be called without any arguments.
+ * If an error is encountered in the stream, this function will stop
+ * consumption and call `cb` with the error.
+ * If the stream contains more than one item, it will throw an error.
+ *
+ * @id toCallback
+ * @section Consumption
+ * @name Stream.toCallback(cb)
+ * @param {Function} cb - the callback to provide the error/result to
+ * @api public
+ *
+ * _([1, 2, 3, 4]).collect().toCallback(function (err, result) {
+ *     // parameter result will be [1,2,3,4]
+ *     // parameter err will be null
+ * });
+ */
+
+Stream.prototype.toCallback = function (cb) {
+    var encounteredError = false;
+    return this.stopOnError(function(err) {
+        encounteredError = true;
+        cb(err);
+    }).take(2).toArray(function (arr) {
+        if (encounteredError) {
+            return;
+        }
+        if (arr.length > 1) {
+            throw new Error('toCallback called on stream emitting multiple values');
+        }
+        else if (arr[0]) {
+            cb(null, arr[0]);
+        }
+        else {
+            cb();
+        }
+    });
+};
+
+/**
  * Creates a new Stream of transformed values by applying a function to each
  * value from the source. The transformation function can be replaced with
  * a non-function value for convenience, and it will emit that value

--- a/test/test.js
+++ b/test/test.js
@@ -1515,6 +1515,60 @@ exports['done - throw error if consumed'] = function (test) {
     test.done();
 };
 
+exports['toCallback - ArrayStream'] = function(test) {
+    _([1,2,3,4]).collect().toCallback(function(err, result) {
+        test.same(result, [1,2,3,4]);
+        test.same(err, null);
+        test.done();
+    });
+}
+
+exports['toCallback - GeneratorStream'] = function (test) {
+    _(function(push, next) {
+        push(null, 1);
+        push(null, 2);
+        setTimeout(function() {
+          push(null, 3);
+          push(null, _.nil);
+        }, 40);
+    }).collect().toCallback(function(err, result){
+        test.same(result, [1,2,3]);
+        test.same(err, null);
+        test.done();
+    });
+}
+
+exports['toCallback - returns error for streams with multiple values'] = function (test) {
+    var s = _([1,2]);
+    test.throws(function () {
+        s.toCallback(function () {});
+    });
+    test.done();
+}
+
+exports['toCallback - calls back without arguments for empty stream'] = function (test) {
+    _([]).toCallback(function() {
+        test.same(arguments.length, 0);
+        test.done();
+    });
+}
+
+exports['toCallback - returns error when stream emits error'] = function (test) {
+    _(function(push, next) {
+        push(null, 1);
+        push(null, 2);
+        setTimeout(function() {
+          push(new Error('Test error'));
+          push(null, 3);
+          push(null, _.nil);
+        }, 40);
+    }).collect().toCallback(function(err, result){
+        test.same(err.message, 'Test error');
+        test.same(result, undefined);
+        test.done();
+    });
+}
+
 exports['calls generator on read'] = function (test) {
     var gen_calls = 0;
     var s = _(function (push, next) {

--- a/test/test.js
+++ b/test/test.js
@@ -1516,6 +1516,7 @@ exports['done - throw error if consumed'] = function (test) {
 };
 
 exports['toCallback - ArrayStream'] = function(test) {
+    test.expect(2);
     _([1,2,3,4]).collect().toCallback(function(err, result) {
         test.same(result, [1,2,3,4]);
         test.same(err, null);
@@ -1524,6 +1525,7 @@ exports['toCallback - ArrayStream'] = function(test) {
 }
 
 exports['toCallback - GeneratorStream'] = function (test) {
+    test.expect(2);
     _(function(push, next) {
         push(null, 1);
         push(null, 2);
@@ -1539,6 +1541,7 @@ exports['toCallback - GeneratorStream'] = function (test) {
 }
 
 exports['toCallback - returns error for streams with multiple values'] = function (test) {
+    test.expect(1);
     var s = _([1,2]).toCallback(function(err, result) {
         test.same(err.message, 'toCallback called on stream emitting multiple values')
         test.done();
@@ -1546,6 +1549,7 @@ exports['toCallback - returns error for streams with multiple values'] = functio
 }
 
 exports['toCallback - calls back without arguments for empty stream'] = function (test) {
+    test.expect(1);
     _([]).toCallback(function() {
         test.same(arguments.length, 0);
         test.done();
@@ -1553,6 +1557,7 @@ exports['toCallback - calls back without arguments for empty stream'] = function
 }
 
 exports['toCallback - returns error when stream emits error'] = function (test) {
+    test.expect(2);
     _(function(push, next) {
         push(null, 1);
         push(null, 2);
@@ -1569,7 +1574,7 @@ exports['toCallback - returns error when stream emits error'] = function (test) 
 }
 
 exports['toCallback - error handling edge cases'] = function (test) {
-    var numCalled = 0;
+    test.expect(4);
     _(function(push, next) {
         push(null, 1);
         push(new Error('Test error'));
@@ -1577,7 +1582,6 @@ exports['toCallback - error handling edge cases'] = function (test) {
     }).toCallback(function(err, result){
         test.same(err.message, 'toCallback called on stream emitting multiple values')
         test.same(result, undefined);
-        numCalled++;
     });
 
     _(function(push, next) {
@@ -1588,9 +1592,7 @@ exports['toCallback - error handling edge cases'] = function (test) {
     }).toCallback(function(err, result){
         test.same(err.message, 'toCallback called on stream emitting multiple values')
         test.same(result, undefined);
-        numCalled++;
     });
-    test.same(numCalled, 2);
     test.done();
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1539,11 +1539,10 @@ exports['toCallback - GeneratorStream'] = function (test) {
 }
 
 exports['toCallback - returns error for streams with multiple values'] = function (test) {
-    var s = _([1,2]);
-    test.throws(function () {
-        s.toCallback(function () {});
+    var s = _([1,2]).toCallback(function(err, result) {
+        test.same(err.message, 'toCallback called on stream emitting multiple values')
+        test.done();
     });
-    test.done();
 }
 
 exports['toCallback - calls back without arguments for empty stream'] = function (test) {
@@ -1567,6 +1566,32 @@ exports['toCallback - returns error when stream emits error'] = function (test) 
         test.same(result, undefined);
         test.done();
     });
+}
+
+exports['toCallback - error handling edge cases'] = function (test) {
+    var numCalled = 0;
+    _(function(push, next) {
+        push(null, 1);
+        push(new Error('Test error'));
+        push(null, _.nil);
+    }).toCallback(function(err, result){
+        test.same(err.message, 'toCallback called on stream emitting multiple values')
+        test.same(result, undefined);
+        numCalled++;
+    });
+
+    _(function(push, next) {
+        push(null, 1);
+        push(null, 2);
+        push(new Error('Test error'));
+        push(null, _.nil);
+    }).toCallback(function(err, result){
+        test.same(err.message, 'toCallback called on stream emitting multiple values')
+        test.same(result, undefined);
+        numCalled++;
+    });
+    test.same(numCalled, 2);
+    test.done();
 }
 
 exports['calls generator on read'] = function (test) {


### PR DESCRIPTION
Wrote this after reading through the discussion here: https://github.com/caolan/highland/issues/484 https://github.com/caolan/highland/pull/488

Main point of concern is that this is throwing an error, I've seen other functions call `this.emit('error', ...)` instead but wasn't sure if it was appropriate here. Since it's programmer error, and isn't really meant to be "caught", I think it should be okay, but open to feedback. There's a doc on Joyent's site that goes more into detail: https://www.joyent.com/developers/node/design/errors (specifically the section titled "(Not) handling programmer errors")