### PR TITLE
Fix for toCallback documentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1726,7 +1726,8 @@ Stream.prototype.done = function (f) {
  * If the stream is empty, `cb` will be called without any arguments.
  * If an error is encountered in the stream, this function will stop
  * consumption and call `cb` with the error.
- * If the stream contains more than one item, it will throw an error.
+ * If the stream contains more than one item, it will stop consumption
+ * and call `cb` with an error.
  *
  * @id toCallback
  * @section Consumption


### PR DESCRIPTION
Just noticed I missed this when changing the throw behavior to the errback behavior.