### PR TITLE
run tests against node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "io.js"
   - "4.0"
   - "5.0"
+  - "6"
+
 sudo: false


### PR DESCRIPTION
Node 6 is going to be the new LTS version so we should be running our tests against it. Also, there's no need to test against iojs anymore.