### PR TITLE
Allow optional custom onFinish handler for Readable constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This file does not aim to be comprehensive (you have git history for that),
 rather it lists changes that might impact your own code as a consumer of
 this library.
 
+2.9.0
+-----
+### New additions
+* It is now possible to pass an custom `onFinish` handler when constructing a
+  Highland Stream from a Node Readable Stream. This allows for special detection
+  of stream completion when necessary.
+  [#505](https://github.com/caolan/highland/pull/505).
+  See [#490](https://github.com/caolan/highland/issues/490) for a discussion on
+  why this is necessary.
+
 2.8.1
 -----
 ### Bugfix

--- a/lib/index.js
+++ b/lib/index.js
@@ -432,11 +432,34 @@ function defaultReadableOnFinish(readable, callback) {
 
 function pipeReadable(xs, onFinish, stream) {
     var cleanup = onFinish(xs, streamEndCb);
+    var unbound = false;
 
     xs.pipe(stream);
 
     // TODO: Replace with onDestroy in v3.
-    stream._destructors.push(function () {
+    stream._destructors.push(unbind);
+
+    function streamEndCb(error) {
+        if (stream._nil_pushed) {
+            return;
+        }
+
+        unbind();
+
+        if (error) {
+            stream.write(new StreamError(error));
+        }
+
+        stream.end();
+    }
+
+    function unbind() {
+        if (unbound) {
+            return;
+        }
+
+        unbound = true;
+
         if (cleanup) {
             cleanup();
         }
@@ -444,18 +467,6 @@ function pipeReadable(xs, onFinish, stream) {
         if (xs.unpipe) {
             xs.unpipe(stream);
         }
-    });
-
-    function streamEndCb(error) {
-        if (stream._nil_pushed) {
-            return;
-        }
-
-        if (error) {
-            stream.write(new StreamError(error));
-        }
-
-        stream.end();
     }
 }
 
@@ -605,10 +616,6 @@ function generatorPush(stream, write) {
     }
 
     return function (err, x) {
-        if (stream._nil_pushed) {
-            throw new Error('Cannot write to stream after nil');
-        }
-
         // This will set _nil_pushed if necessary.
         write.call(stream, err ? new StreamError(err) : x);
     };
@@ -1078,6 +1085,11 @@ Stream.prototype.resume = function () {
  */
 
 Stream.prototype.end = function () {
+    if (this._nil_pushed) {
+        // Allow ending multiple times.
+        return;
+    }
+
     this.write(nil);
 };
 
@@ -1444,6 +1456,10 @@ Stream.prototype.pull = function (f) {
  */
 
 Stream.prototype.write = function (x) {
+    if (this._nil_pushed) {
+        throw new Error('Cannot write to stream after nil');
+    }
+
     // The check for _is_consumer is kind of a hack. Not
     // needed in v3.0.
     if (x === _.nil && !this._is_consumer) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,27 @@ var Decoder = require('string_decoder').StringDecoder;
  * it with the Highland API. Reading from the resulting Highland Stream will
  * begin piping the data from the Node Stream to the Highland Stream.
  *
+ * A stream constructed in this way relies on `Readable#pipe` to end the
+ * Highland Stream once there is no more data. Not all Readable Streams do
+ * this. For example, `IncomingMessage` will only emit `close` when the client
+ * aborts communications and will *not* properly call `end`. In this case, you
+ * can provide an optional `onFinished` function with the signature
+ * `onFinished(readable, callback)` as the second argument.
+ *
+ * This function will be passed the Readable and a callback that should called
+ * when the Readable ends. If the Readable ended from an error, the error
+ * should be passed as the first argument to the callback. `onFinished` should
+ * bind to whatever listener is necessary to detect the Readable's completion.
+ * It may also optionally return a cleanup function that will be called to
+ * unbind any listeners that were added. If the callback is called
+ * multiple times, only the first invocation counts. If the callback is
+ * called *after* the Readable has already ended (e.g., the `pipe`
+ * method already called `end`), it will be ignored.
+ *
+ * See [this issue](https://github.com/caolan/highland/issues/490) for a
+ * discussion on why Highland cannot reliably detect stream completion for
+ * all implementations and why the `onFinished` function is required.
+ *
  * **EventEmitter / jQuery Elements -** Pass in both an event name and an
  * event emitter as the two arguments to the constructor and the first
  * argument emitted to the event handler will be written to the new Stream.
@@ -71,7 +92,8 @@ var Decoder = require('string_decoder').StringDecoder;
  * @section Stream Objects
  * @name _(source)
  * @param {Array | Function | Iterator | Iterable | Promise | Readable Stream | String} source - (optional) source to take values from from
- * @param {EventEmitter | jQuery Element} eventEmitter - (optional) an event emitter. Only valid if `source` is a String.
+ * @param {Function} onFinished - (optional) a function that detects when the readable completes. Second argument. Only valid if `source` is a Readable.
+ * @param {EventEmitter | jQuery Element} eventEmitter - (optional) An event emitter. Second argument. Only valid if `source` is a String.
  * @param {Array | Function | Number} mappingHint - (optional) how to pass the
  * arguments to the callback. Only valid if `source` is a String.
  * @api public
@@ -91,6 +113,20 @@ var Decoder = require('string_decoder').StringDecoder;
  *
  * // wrapping a Node Readable Stream so you can easily manipulate it
  * _(readable).filter(hasSomething).pipe(writeable);
+ *
+ * // wrapping a Readable that may signify completion by emitting `close`
+ * // (e.g., IncomingMessage).
+ * _(req, function (req, callback) {
+ *     req.on('end', callback)
+ *         .on('close', callback)
+ *         .on('error', callback);
+ *
+ *     return function () {
+ *         req.removeListener('end', callback);
+ *         req.removeListener('close', callback);
+ *         req.removeListener('error', callback);
+ *     };
+ * }).pipe(writable);
  *
  * // creating a stream from events
  * _('click', btn).each(handleEvent);
@@ -113,9 +149,9 @@ var Decoder = require('string_decoder').StringDecoder;
  */
 
 /*eslint-disable no-multi-spaces */
-exports = module.exports = function (/*optional*/xs, /*optional*/ee, /*optional*/ mappingHint) {
+exports = module.exports = function (/*optional*/xs, /*optional*/secondArg, /*optional*/ mappingHint) {
     /*eslint-enable no-multi-spaces */
-    return new Stream(xs, ee, mappingHint);
+    return new Stream(xs, secondArg, mappingHint);
 };
 
 var _ = exports;
@@ -379,51 +415,48 @@ function nop() {
     // Do nothing.
 }
 
-function pipeReadable(xs, stream) {
-    var streamEnded = false;
-
-    // write any errors into the stream
-    xs.once('error', writeStreamError);
-
+function defaultReadableOnFinish(readable, callback) {
     // It's possible that `close` is emitted *before* `end`, so we simply
     // cannot handle that case. See
     // https://github.com/caolan/highland/issues/490 for details.
-    //xs.once('close', tryEndStream);
 
-    // We need to bind to 'end' because some streams will emit *both* 'end'
-    // and 'close'. For example, FS streams that complete successfully. Such
-    // streams should not cause Stream#end() to be called twice. Well-behaved
-    // streams should call 'close' after 'end', so we don't have to worry
-    // about finding out about the end of the stream after emitEnd has been
-    // executed.
-    xs.once('end', recordStreamEnded);
+    // pipe already pushes on end, so no need to bind to `end`.
+
+    // write any errors into the stream
+    readable.once('error', callback);
+
+    return function () {
+        readable.removeListener('error', callback);
+    };
+}
+
+function pipeReadable(xs, onFinish, stream) {
+    var cleanup = onFinish(xs, streamEndCb);
 
     xs.pipe(stream);
 
     // TODO: Replace with onDestroy in v3.
     stream._destructors.push(function () {
-        xs.removeListener('error', writeStreamError);
-        xs.removeListener('end', recordStreamEnded);
+        if (cleanup) {
+            cleanup();
+        }
 
         if (xs.unpipe) {
             xs.unpipe(stream);
         }
     });
 
-    function writeStreamError(err) {
-        stream.write(new StreamError(err));
-        tryEndStream();
-    }
-
-    function recordStreamEnded() {
-        streamEnded = true;
-    }
-
-    function tryEndStream() {
-        if (!streamEnded) {
-            streamEnded = true;
-            stream.end();
+    function streamEndCb(error) {
+        console.log(stream._nil_pushed);
+        if (stream._nil_pushed) {
+            return;
         }
+
+        if (error) {
+            stream.write(new StreamError(error));
+        }
+
+        stream.end();
     }
 }
 
@@ -577,10 +610,7 @@ function generatorPush(stream, write) {
             throw new Error('Cannot write to stream after nil');
         }
 
-        if (x === nil) {
-            stream._nil_pushed = true;
-        }
-
+        // This will set _nil_pushed if necessary.
         write.call(stream, err ? new StreamError(err) : x);
     };
 }
@@ -591,7 +621,7 @@ function generatorPush(stream, write) {
  */
 
 /*eslint-disable no-multi-spaces */
-function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
+function Stream(/*optional*/xs, /*optional*/secondArg, /*optional*/mappingHint) {
     /*eslint-enable no-multi-spaces */
     if (xs && _.isStream(xs)) {
         // already a Stream
@@ -690,7 +720,8 @@ function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
     else if (_.isObject(xs)) {
         // check to see if we have a readable stream
         if (_.isFunction(xs.on) && _.isFunction(xs.pipe)) {
-            pipeReadable(xs, self);
+            var onFinish = _.isFunction(secondArg) ? secondArg : defaultReadableOnFinish;
+            pipeReadable(xs, onFinish, self);
             return this;
         }
         else if (_.isFunction(xs.then)) {
@@ -718,7 +749,7 @@ function Stream(/*optional*/xs, /*optional*/ee, /*optional*/mappingHint) {
     else if (_.isString(xs)) {
         var mapper = hintMapper(mappingHint);
 
-        ee.on(xs, function () {
+        secondArg.on(xs, function () {
             var ctx = mapper.apply(this, arguments);
             self.write(ctx);
         });
@@ -1274,6 +1305,9 @@ Stream.prototype.consume = function (f) {
         self = self._delegate;
     }
     var s = new Stream();
+
+    // Hack. Not needed in v3.0.
+    s._is_consumer = true;
     var _send = s._send;
     var push = function (err, x) {
         //console.log(['push', err, x, s.paused]);
@@ -1411,6 +1445,12 @@ Stream.prototype.pull = function (f) {
  */
 
 Stream.prototype.write = function (x) {
+    // The check for _is_consumer is kind of a hack. Not
+    // needed in v3.0.
+    if (x === _.nil && !this._is_consumer) {
+        this._nil_pushed = true;
+    }
+
     if (this.paused) {
         this._incoming.push(x);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -447,7 +447,6 @@ function pipeReadable(xs, onFinish, stream) {
     });
 
     function streamEndCb(error) {
-        console.log(stream._nil_pushed);
         if (stream._nil_pushed) {
             return;
         }

--- a/test/test.js
+++ b/test/test.js
@@ -657,6 +657,38 @@ exports.constructor = {
         s.pull(valueEquals(test, _.nil));
         test.done();
     },
+    'from Readable - unbind and unpipe as soon as possible': function (test) {
+        var rs = new Stream.Readable();
+        rs._read = function (size) {
+            this.push('1');
+            this.push(null);
+        };
+
+        var error = new Error('error');
+        var s = _(rs);
+        var rsPipeDest = getReadablePipeDest(s);
+        var oldWrite = rsPipeDest.write;
+
+        // We need to catch the exception here
+        // since pipe uses process.nextTick which
+        // isn't mocked by sinon.
+        rsPipeDest.write = function (x) {
+            try {
+                oldWrite.call(this, x);
+            } catch (e) {
+            }
+        };
+
+        var write = sinon.spy(rsPipeDest, 'write');
+        rs.emit('error', error);
+
+        _.setImmediate(function () {
+            test.strictEqual(write.callCount, 2);
+            test.strictEqual(write.args[0][0].error, error);
+            test.strictEqual(write.args[1][0], _.nil);
+            test.done();
+        });
+    },
     'from Readable - custom onFinish handler': function (test) {
         test.expect(2);
         var clock = sinon.useFakeTimers();
@@ -666,7 +698,6 @@ exports.constructor = {
         };
 
         var cleanup = sinon.spy();
-        var cleanUpCalled = false;
         var s = _(rs, function (_rs, callback) {
             setTimeout(callback, 1000);
             return cleanup;
@@ -712,7 +743,6 @@ exports.constructor = {
         };
 
         var cleanup = sinon.spy();
-        var cleanUpCalled = false;
         var error = new Error('error');
         var s = _(rs, function (_rs, callback) {
             setTimeout(function () {


### PR DESCRIPTION
Handle the issue raised in #490 in a disciplined way (by punting to the user). We simply allow an extra argument when wrapping a `Readable` that handles the `onFinish` logic for us..