### PR TITLE
Allow onFinished to turn off default endOnError behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ this library.
   [#520](https://github.com/caolan/highland/pull/520).
 * `fromError`: Creates a stream that sends a single error then ends. 
   [#520](https://github.com/caolan/highland/pull/520).  
- 
+* When constructing a Highland stream from a Node Readable, the `onFinish`
+  handler may now turn off the default automatic end on errors behavior by
+  returning an object with the property `continueOnError` set to `true`.
+  [#534](https://github.com/caolan/highland/pull/534).
+  Fixes [#532](https://github.com/caolan/highland/issues/532).
 
 2.9.0
 -----

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,11 +50,19 @@ var Decoder = require('string_decoder').StringDecoder;
  * when the Readable ends. If the Readable ended from an error, the error
  * should be passed as the first argument to the callback. `onFinished` should
  * bind to whatever listener is necessary to detect the Readable's completion.
- * It may also optionally return a cleanup function that will be called to
- * unbind any listeners that were added. If the callback is called
- * multiple times, only the first invocation counts. If the callback is
- * called *after* the Readable has already ended (e.g., the `pipe`
- * method already called `end`), it will be ignored.
+ * If the callback is called multiple times, only the first invocation counts.
+ * If the callback is called *after* the Readable has already ended (e.g., the
+ * `pipe` method already called `end`), it will be ignored.
+ *
+ * The `onFinished` function may optionally return one of the following:
+ *
+ * 1. A cleanup function that will be called when the stream ends. It should
+ * unbind any listeners that were added.
+ * 2. An object with the following optional properties:
+ *    - `onDestroy` - the cleanup function.
+ *    - `continueOnError` - Whether or not to continue the stream when an
+ *      error is passed to the callback. Set this to `true` if the Readable
+ *      may continue to emit values after errors. Default: `false`.
  *
  * See [this issue](https://github.com/caolan/highland/issues/490) for a
  * discussion on why Highland cannot reliably detect stream completion for
@@ -125,6 +133,18 @@ var Decoder = require('string_decoder').StringDecoder;
  *         req.removeListener('end', callback);
  *         req.removeListener('close', callback);
  *         req.removeListener('error', callback);
+ *     };
+ * }).pipe(writable);
+ *
+ * // wrapping a Readable that may emit values after errors.
+ * _(req, function (req, callback) {
+ *     req.on('error', callback);
+ *
+ *     return {
+ *         onDestroy: function () {
+ *             req.removeListener('error', callback);
+ *         },
+ *         continueOnError: true
  *     };
  * }).pipe(writable);
  *
@@ -431,8 +451,19 @@ function defaultReadableOnFinish(readable, callback) {
 }
 
 function pipeReadable(xs, onFinish, stream) {
-    var cleanup = onFinish(xs, streamEndCb);
+    var response = onFinish(xs, streamEndCb);
     var unbound = false;
+
+    var cleanup = null;
+    var endOnError = true;
+
+    if (_.isFunction(response)) {
+        cleanup = response;
+    }
+    else if (response != null) {
+        cleanup = response.cleanup;
+        endOnError = !response.continueOnError;
+    }
 
     xs.pipe(stream);
 
@@ -444,13 +475,14 @@ function pipeReadable(xs, onFinish, stream) {
             return;
         }
 
-        unbind();
-
         if (error) {
             stream.write(new StreamError(error));
         }
 
-        stream.end();
+        if (error == null || endOnError) {
+            unbind();
+            stream.end();
+        }
     }
 
     function unbind() {


### PR DESCRIPTION
Fixes #532.

Allows implementations of `onFinished` (when constructing a Highland stream from a Readable) to turn off the default behavior via `continueOnError`.

```javascript
 _(req, function (req, callback) {
     req.on('error', callback);
     return {
         onDestroy: function () {
             req.removeListener('error', callback);
         },
         continueOnError: true
     };
 }).pipe(writable);
```