### PR TITLE
Standardize the way we show stream values in docs

### DIFF
--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -152,7 +152,7 @@ counter.each(function (n) {
 });</code></pre>
       <p>Passing a function to the <code>toArray</code> call may seem a little unfamiliar, but this enables an important trick in Highland. Now, without changing any of your existing code, you could swap out <code class="javascript">['foo', 'bar', 'baz']</code> for an asynchronous data source, and it would just work!</p>
       <p>You can also pass Arrays into the top-level functions instead of using methods on the Stream object:</p>
-      <pre><code class="javascript">_.map(doubled, [1, 2, 3, 4])  // => 2 4 6 8</code></pre>
+      <pre><code class="javascript">_.map(doubled, [1, 2, 3, 4])  // => 2, 4, 6, 8</code></pre>
       <p>Note, this still returns a Stream.</p>
 
       <h3 id="async">Async</h3>

--- a/lib/index.js
+++ b/lib/index.js
@@ -2651,7 +2651,7 @@ exposeMethod('uniq');
  *     _([7, 8, 9]),
  *     _([10, 11, 12])
  * ]).zipAll0()
- * // => [ 1, 4, 7, 10 ], [ 2, 5, 8, 11 ], [ 3, 6, 9, 12 ]
+ * // => [1, 4, 7, 10], [2, 5, 8, 11], [3, 6, 9, 12]
  *
  * // shortest stream determines length of output stream
  * _([
@@ -2660,7 +2660,7 @@ exposeMethod('uniq');
  *     _([9, 10, 11, 12]),
  *     _([13, 14])
  * ]).zipAll0()
- * // => [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ]
+ * // => [1, 5, 9, 13], [2, 6, 10, 14]
  */
 
 Stream.prototype.zipAll0 = function () {
@@ -2722,11 +2722,11 @@ exposeMethod('zipAll0');
  * @api public
  *
  * _([1,2,3]).zipAll([[4, 5, 6], [7, 8, 9], [10, 11, 12]])
- * // => [ 1, 4, 7, 10 ], [ 2, 5, 8, 11 ], [ 3, 6, 9, 12 ]
+ * // => [1, 4, 7, 10], [2, 5, 8, 11], [3, 6, 9, 12]
  *
  * // shortest stream determines length of output stream
  * _([1, 2, 3, 4]).zipAll([[5, 6, 7, 8], [9, 10, 11, 12], [13, 14]])
- * // => [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ]
+ * // => [1, 5, 9, 13], [2, 6, 10, 14]
  */
 
 Stream.prototype.zipAll = function (ys) {
@@ -2841,9 +2841,9 @@ exposeMethod('batchWithTimeOrCount');
  * @param {String} sep - the value to intersperse between the source elements
  * @api public
  *
- * _(['ba', 'a', 'a']).intersperse('n')  // => ba, n, a, n, a
- * _(['mississippi']).splitBy('ss').intersperse('ss')  // => mi, ss, i, ss, ippi
- * _(['foo']).intersperse('bar')  // => foo
+ * _(['ba', 'a', 'a']).intersperse('n')  // => 'ba', 'n', 'a', 'n', 'a'
+ * _(['mississippi']).splitBy('ss').intersperse('ss')  // => 'mi', 'ss', 'i', 'ss', 'ippi'
+ * _(['foo']).intersperse('bar')  // => 'foo'
  */
 
 Stream.prototype.intersperse = function (separator) {
@@ -2881,9 +2881,9 @@ exposeMethod('intersperse');
  * @param {String | RegExp} sep - the separator to split on
  * @api public
  *
- * _(['mis', 'si', 's', 'sippi']).splitBy('ss')  // => mi, i, ippi
- * _(['ba', 'a', 'a']).intersperse('n').splitBy('n')  // => ba, a, a
- * _(['foo']).splitBy('bar')  // => foo
+ * _(['mis', 'si', 's', 'sippi']).splitBy('ss')  // => 'mi', 'i', 'ippi'
+ * _(['ba', 'a', 'a']).intersperse('n').splitBy('n')  // => 'ba', 'a', 'a'
+ * _(['foo']).splitBy('bar')  // => 'foo'
  */
 
 Stream.prototype.splitBy = function (sep) {
@@ -2928,8 +2928,8 @@ exposeMethod('splitBy');
  * @name Stream.split()
  * @api public
  *
- * _(['a\n', 'b\nc\n', 'd', '\ne']).split()  // => a, b, c, d, e
- * _(['a\r\nb\nc']]).split()  // => a, b, c
+ * _(['a\n', 'b\nc\n', 'd', '\ne']).split()  // => 'a', 'b', 'c', 'd', 'e'
+ * _(['a\r\nb\nc']]).split()  // => 'a', 'b', 'c'
  */
 
 Stream.prototype.split = function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2651,7 +2651,7 @@ exposeMethod('uniq');
  *     _([7, 8, 9]),
  *     _([10, 11, 12])
  * ]).zipAll0()
- * // => [ [ 1, 4, 7, 10 ], [ 2, 5, 8, 11 ], [ 3, 6, 9, 12 ] ]
+ * // => [ 1, 4, 7, 10 ], [ 2, 5, 8, 11 ], [ 3, 6, 9, 12 ]
  *
  * // shortest stream determines length of output stream
  * _([
@@ -2660,7 +2660,7 @@ exposeMethod('uniq');
  *     _([9, 10, 11, 12]),
  *     _([13, 14])
  * ]).zipAll0()
- * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
+ * // => [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ]
  */
 
 Stream.prototype.zipAll0 = function () {
@@ -2722,11 +2722,11 @@ exposeMethod('zipAll0');
  * @api public
  *
  * _([1,2,3]).zipAll([[4, 5, 6], [7, 8, 9], [10, 11, 12]])
- * // => [ [ 1, 4, 7, 10 ], [ 2, 5, 8, 11 ], [ 3, 6, 9, 12 ] ]
+ * // => [ 1, 4, 7, 10 ], [ 2, 5, 8, 11 ], [ 3, 6, 9, 12 ]
  *
  * // shortest stream determines length of output stream
  * _([1, 2, 3, 4]).zipAll([[5, 6, 7, 8], [9, 10, 11, 12], [13, 14]])
- * // => [ [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ] ]
+ * // => [ 1, 5, 9, 13 ], [ 2, 6, 10, 14 ]
  */
 
 Stream.prototype.zipAll = function (ys) {
@@ -3846,7 +3846,7 @@ HighlandTransform.prototype['@@transducer/step'] = function (push, input) {
  *
  * var xf = require('transducer-js').map(_.add(1));
  * _([1, 2, 3, 4]).transduce(xf);
- * // => [2, 3, 4, 5]
+ * // => 2, 3, 4, 5
  */
 
 Stream.prototype.transduce = function transduce(xf) {
@@ -4160,7 +4160,7 @@ exposeMethod('mergeWithLimit');
  * @param {Array} args - the arguments to call the method with
  * @api public
  *
- * _(['foo', 'bar']).invoke('toUpperCase', [])  // => FOO, BAR
+ * _(['foo', 'bar']).invoke('toUpperCase', [])  // => 'FOO', 'BAR'
  *
  * var readFile = _.wrapCallback(fs.readFile);
  * filenames.flatMap(readFile).invoke('toString', ['utf8']);


### PR DESCRIPTION
Update examples in:

- arrays (stream output format)
- transduce (stream output format)
- zipAll (stream output format)
- zipAll0 (stream output format)
- invoke (add missing single quotes around string values)
- intersperse (add missing single quotes around string values)
- split (add missing single quotes around string values)
- splitBy (add missing single quotes around string values)

This resolves #527 
