### PR TITLE
Extend wrapCallback to support promises

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4566,9 +4566,15 @@ _.log = function () {
  * so you can safely use it as a method without binding (see the second
  * example below).
  *
+ * Can also be used to wrap a promise, transforming it to a function which
+ * accepts the same arguments and returns a Highland Stream instead (see the
+ * third example below). The wrapped function keeps its context, so you can
+ * safely use it as a method without binding.
+ *
  * `wrapCallback` also accepts an optional `mappingHint`, which specifies how
  * callback arguments are pushed to the stream. This can be used to handle
  * non-standard callback protocols that pass back more than one value.
+ * `mappingHint` is not applied to promises.
  *
  * `mappingHint` can be a function, number, or array. See the documentation on
  * [EventEmitter Stream Objects](#Stream Objects) for details on the mapping
@@ -4579,7 +4585,7 @@ _.log = function () {
  * @id wrapCallback
  * @section Utils
  * @name _.wrapCallback(f)
- * @param {Function} f - the node-style function to wrap
+ * @param {Function | Promise} f - the node-style function, or promise, to wrap
  * @param {Array | Function | Number} mappingHint - (optional) how to pass the
  * arguments to the callback
  * @api public
@@ -4601,6 +4607,17 @@ _.log = function () {
  * };
  *
  * Reader.prototype.readStream = _.wrapCallback(Reader.prototype.read);
+ *
+ * var Promise = require('bluebird');
+ *
+ * var promiseStream = _.wrapCallback(Promise.resolve([1, 2, 3]));
+ *
+ * promiseStream.apply(function (a, b, c) {
+ *  // a === 1
+ *  // b === 2
+ *  // c === 3
+ * });
+ *
  */
 
 /*eslint-disable no-multi-spaces */

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var inherits = require('util').inherits;
 var deprecate = require('util-deprecate');
 var EventEmitter = require('events').EventEmitter;
 var Decoder = require('string_decoder').StringDecoder;
+var Promise = require('bluebird');
 
 /**
  * The Stream constructor, accepts an array of values or a generator function
@@ -4622,7 +4623,22 @@ _.wrapCallback = function (f, /*optional*/mappingHint) {
                 }
                 push(null, nil);
             };
-            f.apply(self, args.concat([cb]));
+
+            var result = f.apply(self, args.concat([cb]));
+
+            if (_.isObject(result) && _.isFunction(result.then)) {
+                Promise
+                    .resolve(result)
+                    .then(function (value) {
+                        push(null, value);
+                    })
+                    .catch(function (err) {
+                        push(err);
+                    })
+                    .finally(function () {
+                        push(null, nil);
+                    });
+            }
         });
     };
 };

--- a/test/test.js
+++ b/test/test.js
@@ -6539,6 +6539,18 @@ exports.wrapCallback = function (test) {
     });
 };
 
+exports['wrapCallback - promise'] = function (test) {
+    var f = function (a, b) {
+        return new Promise(function (resolve) {
+            resolve(a + b);
+        });
+    };
+    _.wrapCallback(f)(1, 2).toArray(function (xs) {
+        test.same(xs, [3]);
+        test.done();
+    });
+};
+
 exports['wrapCallback - context'] = function (test) {
     var o = {
         f: function (a, b, cb) {
@@ -6546,6 +6558,21 @@ exports['wrapCallback - context'] = function (test) {
             setTimeout(function () {
                 cb(null, a + b);
             }, 10);
+        }
+    };
+    o.g = _.wrapCallback(o.f);
+    o.g(1, 2).toArray(function (xs) {
+        test.same(xs, [3]);
+        test.done();
+    });
+};
+
+exports['wrapCallback - promise context'] = function (test) {
+    var o = {
+        f: function (a, b) {
+            return new Promise(function (resolve) {
+                resolve(a + b);
+            });
         }
     };
     o.g = _.wrapCallback(o.f);
@@ -6565,6 +6592,25 @@ exports['wrapCallback - errors'] = function (test) {
         });
     });
     test.done();
+};
+
+exports['wrapCallback - promise errors'] = function (test) {
+    var errs = [];
+    var f = function (a, b) {
+        return new Promise(function (resolve, reject) {
+            reject(new Error('boom'));
+        });
+    };
+    _.wrapCallback(f)(1, 2)
+        .errors(function (err) {
+            errs.push(err);
+        })
+        .toArray(function (xs) {
+            test.equal(errs[0].message, 'boom');
+            test.equal(errs.length, 1);
+            test.same(xs, []);
+            test.done();
+        });
 };
 
 exports['wrapCallback with args wrapping by function'] = function (test) {


### PR DESCRIPTION
I'm not sure if the best option is to extend wrapCallback (it doesn't make that much sense if we keep the name wrapCallback) or add a wrapPromise function that is similar. I extended it for now and can change as necessary. 

It currently does not support mappingHint for promises. I didn't think it was applicable because there is no callback. What is the best way to handle that? Right now it will just ignore passed mappingHints for promises.

Also, I noticed that the contributing.md file mentioned updating the changelog but the versioning is not clear. Should I add the entry under a new release or the most recent existing one?

addresses #517 