### PR TITLE
Add guidance about certain corner cases in fork() and debounce().

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1564,6 +1564,18 @@ addMethod('write', function (x) {
  * back-pressure. A stream forked to multiple consumers will only pull values
  * from its source as fast as the slowest consumer can handle them.
  *
+ * **NOTE**: Do not depend on a consistent execution order between the forks.
+ * This transform only guarantees that all forks will process a value `foo`
+ * before any will process a second value `bar`. It does *not* guarantee the
+ * order in which the forks process `foo`.
+ *
+ * **TIP**: Be careful about modifying stream values within the forks (or using
+ * a library that does so). Since the same value will be passed to every fork,
+ * changes made in one fork will be visible in fork that executes after it. Add
+ * to that the inconsistent execution order, and you'll have a bad time. If you
+ * need to modify any values, you should make a copy and modify the copy
+ * instead.
+ *
  * @id fork
  * @section Higher-order Streams
  * @name Stream.fork()
@@ -4222,14 +4234,33 @@ addMethod('throttle', function (ms) {
  * data for `ms` milliseconds. Sends the last value that occurred before
  * the delay, discarding all other values.
  *
+ * **Implementation Note**: This transform will will not wait the full `ms`
+ * delay to emit a pending value (if any) once it see a `nil`, as that
+ * guarantees that there will be no more values.
+ *
  * @id debounce
  * @section Transforms
  * @name Stream.debounce(ms)
  * @param {Number} ms - the milliseconds to wait before sending data
  * @api public
  *
+ * function delay(x, ms, push) {
+ *     setTimeout(function () {
+ *         push(null, x);
+ *     }, ms);
+ * }
+ *
  * // sends last keyup event after user has stopped typing for 1 second
  * $('keyup', textbox).debounce(1000);
+ *
+ * // A nil triggers the emit immediately
+ * _(function (push, next) {
+ *     delay(0, 100, push);
+ *     delay(1, 200, push);
+ *     delay(_.nil, 250, push);
+ * }).debounce(75);
+ * // => after 175ms => 1
+ * // => after 250ms (not 275ms!) => 1 2
  */
 
 addMethod('debounce', function (ms) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1571,10 +1571,10 @@ addMethod('write', function (x) {
  *
  * **TIP**: Be careful about modifying stream values within the forks (or using
  * a library that does so). Since the same value will be passed to every fork,
- * changes made in one fork will be visible in fork that executes after it. Add
- * to that the inconsistent execution order, and you'll have a bad time. If you
- * need to modify any values, you should make a copy and modify the copy
- * instead.
+ * changes made in one fork will be visible in any fork that executes after it.
+ * Add to that the inconsistent execution order, and you can end up with subtle
+ * data corruption bugs. If you need to modify any values, you should make a
+ * copy and modify the copy instead.
  *
  * @id fork
  * @section Higher-order Streams


### PR DESCRIPTION
Fixes #555 and #553.