### PR TITLE
Make it clear that pipe should not be used with Highland streams.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1243,11 +1243,12 @@ addMethod('end', function () {
  *
  * This function returns the destination so you can chain together `pipe` calls.
  *
- * **WARNING**: It is almost never correct to do to `pipe` to a Highland
- * stream. Only streams created via `_()` and [pipeline](#pipeline) support
- * being piped to, and those two cases are meant for use *Node* streams. You
- * might be tempted to use `pipe` to construct reusable transforms. Do not do
- * it; it will not work. See [through](#through) for a better way.
+ * **NOTE**: While Highland streams created via `_()` and [pipeline](#pipeline)
+ * support being piped to, it is almost never correct to to `pipe` from a
+ * Highland stream to another Highland stream. Those two cases are meant for
+ * use when piping from *Node* streams. You might be tempted to use `pipe` to
+ * construct reusable transforms. Do not do it; it will not work. See
+ * [through](#through) for a better way.
  *
  * @id pipe
  * @section Consumption

--- a/lib/index.js
+++ b/lib/index.js
@@ -1225,11 +1225,11 @@ addMethod('end', function () {
 });
 
 /**
- * Pipes a Highland Stream to a [Node Writable Stream](http://nodejs.org/api/stream.html#stream_class_stream_writable)
- * (Highland Streams are also Node Writable Streams). This will pull all the
- * data from the source Highland Stream and write it to the destination,
- * automatically managing flow so that the destination is not overwhelmed
- * by a fast source.
+ * Pipes a Highland Stream to a [Node Writable
+ * Stream](http://nodejs.org/api/stream.html#stream_class_stream_writable).
+ * This will pull all the data from the source Highland Stream and write it to
+ * the destination, automatically managing flow so that the destination is not
+ * overwhelmed by a fast source.
  *
  * Users may optionally pass an object that may contain any of these fields:
  *
@@ -1239,10 +1239,15 @@ addMethod('end', function () {
  *
  * Like [Readable#pipe](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options),
  * this function will throw errors if there is no `error` handler installed on
- * the stream. Use [through](#through) if you are piping to another Highland
- * stream and want errors as well as values to be propagated.
+ * the stream.
  *
- * This function returns the destination so you can chain together pipe calls.
+ * This function returns the destination so you can chain together `pipe` calls.
+ *
+ * **WARNING**: It is almost never correct to do to `pipe` to a Highland
+ * stream. Only streams created via `_()` and [pipeline](#pipeline) support
+ * being piped to, and those two cases are meant for use *Node* streams. You
+ * might be tempted to use `pipe` to construct reusable transforms. Do not do
+ * it; it will not work. See [through](#through) for a better way.
  *
  * @id pipe
  * @section Consumption
@@ -1257,6 +1262,19 @@ addMethod('end', function () {
  *
  * // chained call
  * source.pipe(through).pipe(dest);
+ *
+ * // DO NOT do this! It will not work. The stream returned by oddDoubler does
+ * // not support being piped to.
+ * function oddDoubler() {
+ *     return _()
+ *         return x % 2; // odd numbers only
+ *     })
+ *     .map(function (x) {
+ *         return x * 2;
+ *     });
+ * }
+ *
+ * _([1, 2, 3, 4]).pipe(oddDoubler()) // => Garbage
  */
 
 addMethod('pipe', function (dest, options) {
@@ -3123,6 +3141,10 @@ addMethod('sort', function () {
  * Highland Stream (instead of the piped to target directly as in
  * [pipe](#pipe)). Any errors emitted will be propagated as Highland errors.
  *
+ * **TIP**: Passing a function to `through` is a good way to implement complex
+ * reusable stream transforms. You can even construct the function dynamically
+ * based on certain inputs. See examples below.
+ *
  * @id through
  * @section Higher-order Streams
  * @name Stream.through(target)
@@ -3130,6 +3152,7 @@ addMethod('sort', function () {
  * function to call.
  * @api public
  *
+ * // This is a static complex transform.
  * function oddDoubler(s) {
  *     return s.filter(function (x) {
  *         return x % 2; // odd numbers only
@@ -3139,9 +3162,21 @@ addMethod('sort', function () {
  *     });
  * }
  *
- * _([1, 2, 3, 4]).through(oddDoubler).toArray(function (xs) {
- *     // xs will be [2, 6]
- * });
+ * // This is a dynamically-created complex transform.
+ * function multiplyEvens(factor) {
+ *     return function (x) {
+ *         return s.filter(function (x) {
+ *             return x % 2 === 0;
+ *         })
+ *         .map(function (x) {
+ *             return x * factor;
+ *         });
+ *     };
+ * }
+ *
+ * _([1, 2, 3, 4]).through(oddDoubler); // => 2, 6
+ *
+ * _([1, 2, 3, 4]).through(multiplyEvens(5)); // => 10, 20
  *
  * // Can also be used with Node Through Streams
  * _(filenames).through(jsonParser).map(function (obj) {


### PR DESCRIPTION
Address the confusion from #559 about the intended uses of `pipe`. This is not the first time someone has gotten confused about it, likely because node streams use `pipe` for doing stream transformations, so people (reasonably) think that is how Highland works too.