### PR TITLE
Make sure uncaught errors are correctly logged. Fixes #589.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -613,32 +613,36 @@ function newDelegateGenerator(pull) {
 }
 
 function promiseStream(StreamCtor, promise) {
-    if (_.isFunction(promise['finally'])) { // eslint-disable-line dot-notation
-        // Using finally handles also bluebird promise cancellation
-        return new StreamCtor(function (push) {
-            promise.then(function (value) {
-                return push(null, value);
-            },
-                function (err) {
-                    return push(err);
-                })['finally'](function () { // eslint-disable-line dot-notation
-                    return push(null, nil);
-                });
-        });
-    }
-    else {
-        // Sticking to promise standard only
-        return new StreamCtor(function (push) {
-            promise.then(function (value) {
+    var nilScheduled = false;
+    return new StreamCtor(function (push) {
+        // We need to push asynchronously so that errors thrown from handling
+        // these values are not caught by the promise.
+        promise = promise.then(function (value) {
+            nilScheduled = true;
+            _.setImmediate(function () {
                 push(null, value);
-                return push(null, nil);
-            },
-            function (err) {
+                push(null, nil);
+            });
+        }, function (err) {
+            nilScheduled = true;
+            _.setImmediate(function () {
                 push(err);
-                return push(null, nil);
+                push(null, nil);
             });
         });
-    }
+
+        // Using finally also handles bluebird promise cancellation, so we do
+        // it if we can.
+        if (_.isFunction(promise['finally'])) { // eslint-disable-line dot-notation
+            promise['finally'](function () { // eslint-disable-line dot-notation
+                if (!nilScheduled) {
+                    _.setImmediate(function () {
+                        push(null, nil);
+                    });
+                }
+            });
+        }
+    });
 }
 
 function iteratorStream(StreamCtor, it) {

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,23 @@ function noValueOnErrorTest(transform, expected) {
     };
 }
 
+function catchEventLoopError(highland, cb) {
+    var oldSetImmediate = highland.setImmediate;
+    highland.setImmediate = function (fn) {
+        oldSetImmediate(function () {
+            try {
+                fn();
+            }
+            catch (e) {
+                cb(e);
+            }
+        });
+    };
+    return function () {
+        highland.setImmediate = oldSetImmediate;
+    };
+}
+
 function onDestroyTest(transform, input, takeFirst) {
     var called = 0,
         destroy1 = false,
@@ -966,6 +983,87 @@ exports.constructor = {
         });
         var stream = _(promise).toArray(this.tester([], test));
         promise.cancel();
+    },
+    'from promise - should not throw in promise onResolve handler (issue #589)': function (test) {
+        test.expect(1);
+
+        // Swallow the exception so the tests passes.
+        var stopCatchingEventLoopError = catchEventLoopError(_, function (e) {
+            if (e.message !== 'Error thrown when handling value.') {
+                throw e;
+            }
+        });
+
+        var promise = bluebird.Promise.resolve('value');
+        var oldThen = promise.then;
+        promise.then = function (onResolve, onReject) {
+            return oldThen.call(promise, function () {
+                var threwError = false;
+                try {
+                    onResolve.apply(this, arguments);
+                }
+                catch (e) {
+                    threwError = true;
+                }
+
+                test.ok(!threwError, 'The onResolve callback synchronously threw!');
+                test.done();
+                stopCatchingEventLoopError();
+            }, function () {
+                // Won't be called.
+                test.ok(false, 'The onReject callback was called?!');
+                test.done();
+                stopCatchingEventLoopError();
+            });
+        };
+
+        // Clear promise.finally to force the use of the vanilla promise code
+        // path.
+        promise.finally = null;
+        _(promise)
+            .map(function (x) {
+                throw new Error('Error thrown when handling value.');
+            })
+            .done(function () {});
+    },
+    'from promise - should not throw in promise onReject handler (issue #589)': function (test) {
+        test.expect(1);
+
+        // Swallow the exception so the tests passes.
+        var stopCatchingEventLoopError = catchEventLoopError(_, function (e) {
+            if (e.message !== 'Error from promise.') {
+                throw e;
+            }
+        });
+
+        var promise = bluebird.Promise.reject(new Error('Error from promise.'));
+        var oldThen = promise.then;
+        promise.then = function (onResolve, onReject) {
+            return oldThen.call(promise, function () {
+                // Won't be called.
+                test.ok(false, 'The onResolve callback was called?!');
+                test.done();
+                stopCatchingEventLoopError();
+            }, function () {
+                var threwError = false;
+                try {
+                    onReject.apply(this, arguments);
+                }
+                catch (e) {
+                    threwError = true;
+                }
+
+                test.ok(!threwError, 'The onReject callback synchronously threw!');
+                test.done();
+                stopCatchingEventLoopError();
+            });
+        };
+
+        // Clear promise.finally to force the use of the vanilla promise code
+        // path.
+        promise.finally = null;
+        _(promise).done(function () {});
+
     },
     'from iterator': function (test) {
         test.expect(1);


### PR DESCRIPTION
We signify uncaught errors by doing this.emit('error'). This throws an
error if there are no bound handlers. Previously, for promise-based
streams, such thrown errors may propagate up to the promise and be
swallowed by whatever promise implementation the user is using.

We can push data asynchonously to fix this problem.