### PR TITLE
Make sure uncaught errors are correctly logged. Fixes #589.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ this library.
   correctly logged.
   [#591](https://github.com/caolan/highland/pull/591).
   Fixes [#589](https://github.com/caolan/highland/issues/589).
+* Users using bluebird as their Promise implementation may have seen an error
+  that says "a promise was created in a handler at ... but was not returned from
+  it". This is a false positive, and Highland's use of promises have been
+  updated to suppress this warning.
+  [#588](https://github.com/caolan/highland/issues/588).
 
 2.10.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This file does not aim to be comprehensive (you have git history for that),
 rather it lists changes that might impact your own code as a consumer of
 this library.
 
+2.10.2
+------
+### Bugfix
+* Uncaught errors from promise-back streams weren't being correctly logged in
+  certain circumstances when using a Promise implementation that does not log
+  unhandled promise exceptions. All uncaught highland errors should now be
+  correctly logged.
+  [#591](https://github.com/caolan/highland/pull/591).
+  Fixes [#589](https://github.com/caolan/highland/issues/589).
+
 2.10.1
 ------
 ### Bugfix

--- a/lib/index.js
+++ b/lib/index.js
@@ -510,32 +510,42 @@ function pipeReadable(xs, onFinish, stream) {
 }
 
 function promiseStream(promise) {
-    if (_.isFunction(promise['finally'])) { // eslint-disable-line dot-notation
-        // Using finally handles also bluebird promise cancellation
-        return _(function (push) {
-            promise.then(function (value) {
-                return push(null, value);
-            },
-                function (err) {
-                    return push(err);
-                })['finally'](function () { // eslint-disable-line dot-notation
-                    return push(null, nil);
-                });
-        });
-    }
-    else {
-        // Sticking to promise standard only
-        return _(function (push) {
-            promise.then(function (value) {
+    var nilScheduled = false;
+    return _(function (push) {
+        // We need to push asynchronously so that errors thrown from handling
+        // these values are not caught by the promise. Also, return null so
+        // that bluebird-based promises don't complain about handlers being
+        // created but not returned. See
+        // https://github.com/caolan/highland/issues/588.
+        promise = promise.then(function (value) {
+            nilScheduled = true;
+            _.setImmediate(function () {
                 push(null, value);
-                return push(null, nil);
-            },
-                function (err) {
-                    push(err);
-                    return push(null, nil);
-                });
+                push(null, nil);
+            });
+            return null;
+        }, function (err) {
+            nilScheduled = true;
+            _.setImmediate(function () {
+                push(err);
+                push(null, nil);
+            });
+            return null;
         });
-    }
+
+        // Using finally also handles bluebird promise cancellation, so we do
+        // it if we can.
+        if (_.isFunction(promise['finally'])) { // eslint-disable-line dot-notation
+            promise['finally'](function () { // eslint-disable-line dot-notation
+                if (!nilScheduled) {
+                    _.setImmediate(function () {
+                        push(null, nil);
+                    });
+                }
+                return null;
+            });
+        }
+    });
 }
 
 function iteratorStream(it) {

--- a/test/test.js
+++ b/test/test.js
@@ -78,6 +78,23 @@ function noValueOnErrorTest(transform, expected) {
     };
 }
 
+function catchEventLoopError(highland, cb) {
+    var oldSetImmediate = highland.setImmediate;
+    highland.setImmediate = function (fn) {
+        oldSetImmediate(function () {
+            try {
+                fn();
+            }
+            catch (e) {
+                cb(e);
+            }
+        });
+    };
+    return function () {
+        highland.setImmediate = oldSetImmediate;
+    };
+}
+
 function generatorStream(input, timeout) {
     return _(function (push, next) {
         for (var i = 0, len = input.length; i < len; i++) {
@@ -884,6 +901,87 @@ exports.constructor = {
         });
         var stream = _(promise).toArray(this.tester([], test));
         promise.cancel();
+    },
+    'from promise - should not throw in promise onResolve handler (issue #589)': function (test) {
+        test.expect(1);
+
+        // Swallow the exception so the tests passes.
+        var stopCatchingEventLoopError = catchEventLoopError(_, function (e) {
+            if (e.message !== 'Error thrown when handling value.') {
+                throw e;
+            }
+        });
+
+        var promise = bluebird.Promise.resolve('value');
+        var oldThen = promise.then;
+        promise.then = function (onResolve, onReject) {
+            return oldThen.call(promise, function () {
+                var threwError = false;
+                try {
+                    onResolve.apply(this, arguments);
+                }
+                catch (e) {
+                    threwError = true;
+                }
+
+                test.ok(!threwError, 'The onResolve callback synchronously threw!');
+                test.done();
+                stopCatchingEventLoopError();
+            }, function () {
+                // Won't be called.
+                test.ok(false, 'The onReject callback was called?!');
+                test.done();
+                stopCatchingEventLoopError();
+            });
+        };
+
+        // Clear promise.finally to force the use of the vanilla promise code
+        // path.
+        promise.finally = null;
+        _(promise)
+            .map(function (x) {
+                throw new Error('Error thrown when handling value.');
+            })
+            .done(function () {});
+    },
+    'from promise - should not throw in promise onReject handler (issue #589)': function (test) {
+        test.expect(1);
+
+        // Swallow the exception so the tests passes.
+        var stopCatchingEventLoopError = catchEventLoopError(_, function (e) {
+            if (e.message !== 'Error from promise.') {
+                throw e;
+            }
+        });
+
+        var promise = bluebird.Promise.reject(new Error('Error from promise.'));
+        var oldThen = promise.then;
+        promise.then = function (onResolve, onReject) {
+            return oldThen.call(promise, function () {
+                // Won't be called.
+                test.ok(false, 'The onResolve callback was called?!');
+                test.done();
+                stopCatchingEventLoopError();
+            }, function () {
+                var threwError = false;
+                try {
+                    onReject.apply(this, arguments);
+                }
+                catch (e) {
+                    threwError = true;
+                }
+
+                test.ok(!threwError, 'The onReject callback synchronously threw!');
+                test.done();
+                stopCatchingEventLoopError();
+            });
+        };
+
+        // Clear promise.finally to force the use of the vanilla promise code
+        // path.
+        promise.finally = null;
+        _(promise).done(function () {});
+
     },
     'from iterator': function (test) {
         test.expect(1);


### PR DESCRIPTION
We signify uncaught errors by doing this.emit('error'). This throws an
error if there are no bound handlers. Previously, for promise-based
streams, such thrown errors may propagate up to the promise and be
swallowed by whatever promise implementation the user is using.

We can push data asynchonously to fix this problem. While we're at it,
also return null from promise handlers so that bluebird doesn't
complain. See #588.