### PR TITLE
[trivial] fixed variable name typo in `.through` docstring

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3214,7 +3214,7 @@ addMethod('sort', function () {
  *
  * // This is a dynamically-created complex transform.
  * function multiplyEvens(factor) {
- *     return function (x) {
+ *     return function (s) {
  *         return s.filter(function (x) {
  *             return x % 2 === 0;
  *         })


### PR DESCRIPTION
Should be `s`, not `x`