### PR TITLE
implement toNodeStream()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This file does not aim to be comprehensive (you have git history for that),
 rather it lists changes that might impact your own code as a consumer of
 this library.
 
+2.12.0
+------
+### New additions
+* `toNodeStream`: Returns a native node Readable
+  [#644](https://github.com/caolan/highland/pull/644)
+
 2.11.1
 ------
 ### Bugfix

--- a/lib/index.js
+++ b/lib/index.js
@@ -2057,17 +2057,24 @@ exposeMethod('toPromise');
  * Converts the stream to a node Readable Stream for use in methods
  * or pipes that depend on the native stream type.
  *
+ * The options parameter can be an object passed into the
+ * [`Readable`](http://nodejs.org/api/stream.html#stream_class_stream_readable)
+ * constructor.
+ *
  * @id toNodeStream
  * @section Consumption
- * @name Stream.toNodeStream()
+ * @name Stream.toNodeStream(options)
+ * @param {Object} options - (optional) [`Readable` constructor](http://nodejs.org/api/stream.html#stream_class_stream_readable) options
  * @api public
  *
- * _([1, 2, 3, 4]).collect().toNodeStream() // instance of Readable
+ * _(fs.createReadStream('./abc')).toNodeStream(false)
+ * _([{a: 1}]).toNodeStream(true)
+ * _([{a: 1}]).toNodeStream({objectMode: true})
  */
 
-Stream.prototype.toNodeStream = function () {
+Stream.prototype.toNodeStream = function (options) {
     var self = this;
-    return new Readable().wrap(self);
+    return new Readable(options).wrap(self);
 };
 exposeMethod('toNodeStream');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var inherits = require('util').inherits;
 var deprecate = require('util-deprecate');
 var EventEmitter = require('events').EventEmitter;
 var Decoder = require('string_decoder').StringDecoder;
+var Readable = require('stream').Readable;
 
 /**
  * The Stream constructor, accepts an array of values or a generator function
@@ -2050,6 +2051,25 @@ Stream.prototype.toPromise = function (PromiseCtor) {
     });
 };
 exposeMethod('toPromise');
+
+
+/**
+ * Converts the stream to a node Readable Stream for use in methods
+ * or pipes that depend on the native stream type.
+ *
+ * @id toNodeStream
+ * @section Consumption
+ * @name Stream.toNodeStream()
+ * @api public
+ *
+ * _([1, 2, 3, 4]).collect().toNodeStream() // instance of Readable
+ */
+
+Stream.prototype.toNodeStream = function () {
+    var self = this;
+    return new Readable().wrap(self);
+};
+exposeMethod('toNodeStream');
 
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -2067,8 +2067,8 @@ exposeMethod('toPromise');
  * @param {Object} options - (optional) [`Readable` constructor](http://nodejs.org/api/stream.html#stream_class_stream_readable) options
  * @api public
  *
- * _(fs.createReadStream('./abc')).toNodeStream(false)
- * _([{a: 1}]).toNodeStream(true)
+ * _(fs.createReadStream('./abc')).toNodeStream()
+ * _(fs.createReadStream('./abc')).toNodeStream({objectMode: false})
  * _([{a: 1}]).toNodeStream({objectMode: true})
  */
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test": "eslint Gruntfile.js lib test/test.js && nodeunit test/test.js"
   },
   "dependencies": {
+    "stream-browserify": "^2.0.1",
     "util-deprecate": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "test": "eslint Gruntfile.js lib test/test.js && nodeunit test/test.js"
   },
   "dependencies": {
-    "stream-browserify": "^2.0.1",
     "util-deprecate": "^1.0.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2046,7 +2046,8 @@ exports.toPromise = {
 
 exports.toNodeStream = {
     'non-object stream of buffer': function (test) {
-        var buf = Buffer.from('aaa', 'utf8');
+        var buf = Buffer.from ? Buffer.from('aaa', 'utf8')
+                              : new Buffer('aaa', 'utf8');
         var s = _.of(buf).toNodeStream();
         s.on('data', function(val) {
             test.same(val, buf);

--- a/test/test.js
+++ b/test/test.js
@@ -2044,6 +2044,53 @@ exports.toPromise = {
     }
 };
 
+exports.toNodeStream = {
+    'non-object stream of buffer': function (test) {
+        var buf = Buffer.from('aaa', 'utf8');
+        var s = _.of(buf).toNodeStream();
+        s.on('data', function(val) {
+            test.same(val, buf);
+        });
+        s.on('end', function() {
+            test.done();
+        });
+    },
+    'non-object stream of string': function (test) {
+        var s = _.of('aaa').toNodeStream({objectMode: true});
+        s.on('data', function(val) {
+            test.same(val, 'aaa');
+        });
+        s.on('end', function() {
+            test.done();
+        });
+    },
+    'object stream': function (test) {
+        var s = _.of({a: 1}).toNodeStream({objectMode: true});
+        s.on('data', function(val) {
+            test.same(val, {a: 1});
+        });
+        s.on('end', function(val) {
+            test.done();
+        });
+    },
+    'object stream no objectmode': function (test) {
+        var s = _.of({a: 1}).toNodeStream();
+        s.on('data', function(val) {
+            test.ok(false, 'data event should not be fired');
+        });
+        s.on('end', function(val) {
+            test.done();
+        });
+    },
+    'object stream but stream error': function (test) {
+        var err = new Error('ohno');
+        var s = _.fromError(err).toNodeStream({objectMode: true});
+        s.on('error', function (e) {
+            test.same(e, err);
+            test.done();
+        });
+    }
+};
 
 exports['calls generator on read'] = function (test) {
     var gen_calls = 0;

--- a/test/test.js
+++ b/test/test.js
@@ -2046,8 +2046,7 @@ exports.toPromise = {
 
 exports.toNodeStream = {
     'non-object stream of buffer': function (test) {
-        var buf = Buffer.from ? Buffer.from('aaa', 'utf8')
-                              : new Buffer('aaa', 'utf8');
+        var buf = new Buffer('aaa', 'utf8');
         var s = _.of(buf).toNodeStream();
         s.on('data', function(val) {
             test.same(val, buf);


### PR DESCRIPTION
There had been some discussion in [#279 - To Nodejs Stream](https://github.com/caolan/highland/issues/279) of a toNodeStream method, which I've implemented here.

Inclusion of the stream-browserify package means this should build seamlessly for the purposes of non-node environments and use a shim in those cases.