### PR TITLE
feat: add `isNil` for type checking

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -918,6 +918,20 @@ function StreamRedirect(to) {
 }
 
 /**
+ * Returns true if `x` is the end of stream marker.
+ *
+ * @id isNil
+ * @section Streams
+ * @name _.isNil(x)
+ * @param x - the object to test
+ * @api public
+ */
+
+_.isNil = function (x) {
+    return x === _.nil;
+};
+
+/**
  * Returns true if `x` is a Highland Stream.
  *
  * @id isStream

--- a/test/test.js
+++ b/test/test.js
@@ -324,6 +324,19 @@ exports.seq = function (test) {
     test.done();
 };
 
+exports.isNilTest = function (test) {
+    test.ok(_.isNil(_.nil));
+    test.ok(!_.isNil());
+    test.ok(!_.isNil(undefined));
+    test.ok(!_.isNil(null));
+    test.ok(!_.isNil(123));
+    test.ok(!_.isNil({}));
+    test.ok(!_.isNil([]));
+    test.ok(!_.isNil('foo'));
+    test.ok(!_.isNil(_()));
+    test.done();
+};
+
 exports.isStream = function (test) {
     test.ok(!_.isStream());
     test.ok(!_.isStream(undefined));


### PR DESCRIPTION
This PR provides a very simple, and yet essential, function for type checking, as
_.nil is not a primitive variable but an object. This function is particularly
useful in a consume handler which has a signature of `consume<U>(f: (err: Error,
x: R | Highland.Nil, push: (err: Error | null, value?: U | Highland.Nil) =>
void, next: () => void) => void): Stream<U>`. Only with this function and an
updated typescript or flow definition, x can be distinguished between R and Highland.Nil.

Example:
```typescript
source.consume(function (err, x, push, next) {
  if (err) {
    // pass errors along the stream and consume next value
    push(err);
    next();
  } else if (_.isNil(x)) { // type guard is only possible with this function
    // pass nil (end event) along the stream
    push(null, x);
  } else {
    // pass on the value only if the value passes the predicate
    if (f(x)) {
      push(null, x);
    }
    next();
  }
});
```

Note: This PR also comes with a simple test.