### PR TITLE
Update documentation for stopOnError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This release contains all changes from [2.12.0](#2120).
   Also, in 2.x, calling `toNodeStream` will immediately consume the source. In
   3.x, the source stream will only be consumed when the `Readable` is consumed.
 
+### Other
+* `stopOnError` - update `stopOnError` documentation to include `push`
+  [#650](https://github.com/caolan/highland/pull/650).
+
 3.0.0-beta.5
 -----
 ### Breaking changes

--- a/lib/index.js
+++ b/lib/index.js
@@ -1758,8 +1758,11 @@ addMethod('errors', function (f) {
  * @param {Function} f - the function to handle an error
  * @api public
  *
- * brokenStream.stopOnError(function (err) {
- *     //console.error('Something broke: ' + err);
+ * brokenStream.stopOnError(function (err, push) {
+ *     // console.error('Something broke: ' + err);
+ *
+ *     // Rethrow if needed
+ *     // push(err);
  * });
  */
 


### PR DESCRIPTION
The `stopOnError` method invokes the provided function with both the error and the push function. This is useful for optionally rethrowing an error, defaulting to stopping the stream on error.