### PR TITLE
Implement flatTap

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2168,6 +2168,28 @@ Stream.prototype.tap = Stream.prototype.doto;
 _.tap = _.doto;
 
 /**
+ * Applies a function to each value from the source, and re-emits the
+ * source value
+ *
+ * @id flatTap
+ * @section Transforms
+ * @name Stream.flatTap(f)
+ * @param {Function} f - the function to apply
+ * @api public
+ *
+ * _([1, 2, 3]).flatTap(httpLog)
+ */
+
+addMethod('flatTap', function (f) {
+    return this.flatMap(function (x) {
+        return f(x)
+            .flatMap(function () {
+                return _([x]);
+            });
+    });
+});
+
+/**
  * Limits number of values through the stream to a maximum of number of values
  * per window. Errors are not limited but allowed to pass through as soon as
  * they are read from the source.

--- a/test/test.js
+++ b/test/test.js
@@ -4930,7 +4930,7 @@ exports.flatTap = function (test) {
 exports['flatTap - noValueOnError'] = noValueOnErrorTest(_.doto(function (x) { return x; }));
 
 exports['flatTap - returnsSameStream'] = returnsSameStreamTest(function(s) {
-    return s.doto(function (x) { return x; });
+    return s.flatTap(function (x) { return _([x]); });
 });
 
 exports.flatMap = function (test) {

--- a/test/test.js
+++ b/test/test.js
@@ -4909,6 +4909,30 @@ exports['tap - doto alias'] = function (test) {
     test.done();
 };
 
+exports.flatTap = function (test) {
+    test.expect(2);
+
+    var seen;
+    function record(x) {
+        var y = x * 2;
+        seen.push(y);
+        return _([y]);
+    }
+
+    seen = [];
+    _.flatTap(record, [1, 2, 3, 4]).toArray(function (xs) {
+        test.same(xs, [1, 2, 3, 4]);
+        test.same(seen, [2, 4, 6, 8]);
+    });
+    test.done();
+};
+
+exports['flatTap - noValueOnError'] = noValueOnErrorTest(_.doto(function (x) { return x; }));
+
+exports['flatTap - returnsSameStream'] = returnsSameStreamTest(function(s) {
+    return s.doto(function (x) { return x; });
+});
+
 exports.flatMap = function (test) {
     var f = function (x) {
         return _(function (push, next) {


### PR DESCRIPTION
From Issue #616

This method creates a short hand for the following:

`stream.flatMap(item => save.map(_ => item))`

where save returns a highland stream.