### PR TITLE
Add and test `empty` method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1002,6 +1002,22 @@ addToplevelMethod('of', function (x) {
 });
 
 /**
+ * Creates an empty stream.
+ *
+ * @id empty
+ * @section Utils
+ * @name _.empty()
+ * @returns Stream
+ * @api public
+ *
+ * _.empty().toArray(_.log); // => []
+ */
+
+addToplevelMethod('empty', function () {
+    return _([]);
+});
+
+/**
  * Creates a stream that sends a single error then ends.
  *
  * @id fromError

--- a/lib/index.js
+++ b/lib/index.js
@@ -1014,7 +1014,7 @@ addToplevelMethod('of', function (x) {
  */
 
 addToplevelMethod('empty', function () {
-    return _([]);
+    return this([]);
 });
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -1624,7 +1624,7 @@ exports.of = {
 };
 
 exports.empty = {
-    'creates stream with no values': function (test) {
+    'creates a stream with no values': function (test) {
         test.expect(2);
         _.empty()
             .toCallback(function (err, result) {
@@ -1632,6 +1632,44 @@ exports.empty = {
                 test.same(result, undefined);
                 test.done();
             });
+    },
+    'right identity': {
+        'm.concat(M.empty()) is equivalent to m': function (test) {
+            test.expect(3);
+            var m = _.of(1);
+
+            _([
+                m.fork().collect(),
+                m.observe().concat(_.empty()).collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, [1]);
+                    test.same(rights, [1]);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
+    },
+    'left identity': {
+        'M.empty().concat(m) is equivalent to m': function (test) {
+            test.expect(3);
+            var m = _.of(1);
+
+            _([
+                m.fork().collect(),
+                _.empty().concat(m.observe()).collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, [1]);
+                    test.same(rights, [1]);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -1623,6 +1623,18 @@ exports.of = {
     }
 };
 
+exports.empty = {
+    'creates stream with no values': function (test) {
+        test.expect(2);
+        _.empty()
+            .toCallback(function (err, result) {
+                test.ifError(err);
+                test.same(result, undefined);
+                test.done();
+            });
+    }
+};
+
 exports.fromError = {
     'creates stream of one error': function (test) {
         var error = new Error('This is an error');


### PR DESCRIPTION
`empty` creates a stream with no values.

This turns a Highland stream into a [Monoid](https://github.com/fantasyland/fantasy-land#monoid)