### PR TITLE
Add fantasy-land canonical method names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1002,6 +1002,8 @@ _.use = use(Stream, _);
 addToplevelMethod('of', function (x) {
     return _([x]);
 });
+Stream.prototype[fl.of] = Stream.prototype.of;
+_[fl.of] = _.of;
 
 /**
  * Creates a stream that sends a single error then ends.

--- a/lib/index.js
+++ b/lib/index.js
@@ -3743,6 +3743,8 @@ addMethod('otherwise', function (ys) {
         }
     });
 });
+Stream.prototype[fl.alt] = Stream.prototype.otherwise;
+_[fl.alt] = _.otherwise;
 
 /**
  * Adds a value to the end of a Stream.

--- a/lib/index.js
+++ b/lib/index.js
@@ -2240,6 +2240,8 @@ addMethod('ratelimit', function (num, ms) {
 addMethod('flatMap', function (f) {
     return this.map(f).sequence();
 });
+Stream.prototype[fl.chain] = Stream.prototype.flatMap;
+_[fl.chain] = _.flatMap;
 
 /**
  * Retrieves values associated with a given property from all elements in

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,8 @@ var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 var Decoder = require('string_decoder').StringDecoder;
 
+var fl = require('fantasy-land');
+
 var IntMap = require('./intMap');
 var Queue = require('./queue');
 var ReadableProxy = require('./readableProxy');
@@ -2122,6 +2124,8 @@ addMethod('map', function (f) {
         }
     });
 });
+Stream.prototype[fl.map] = Stream.prototype.map;
+_[fl.map] = _.map;
 
 /**
  * Creates a new Stream which applies a function to each value from the source

--- a/lib/index.js
+++ b/lib/index.js
@@ -4097,6 +4097,8 @@ addMethod('concat', function (ys) {
         }
     });
 });
+Stream.prototype[fl.concat] = Stream.prototype.concat;
+_[fl.concat] = _.concat;
 
 /**
  * Takes a Stream of Streams and merges their values and errors into a

--- a/lib/index.js
+++ b/lib/index.js
@@ -2453,6 +2453,8 @@ addMethod('filter', function (f) {
         }
     });
 });
+Stream.prototype[fl.filter] = Stream.prototype.filter;
+_[fl.filter] = _.filter;
 
 /**
  * Filters using a predicate which returns a Stream. If you need to check

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "test": "eslint Gruntfile.js lib test/test.js && npm run nodeunit",
     "test-0.10": "npm run nodeunit",
     "nodeunit": "nodeunit test/test.js"
+  },
+  "dependencies": {
+    "fantasy-land": "^3.5.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -5051,6 +5051,37 @@ exports['flatMap - map to Stream of Array'] = function (test) {
     });
 };
 
+exports['flatMap - chain'] = {
+    'associativity': {
+        'm.chain(f).chain(g) is equivalent to m.chain(x => f(x).chain(g))': function (test) {
+            test.expect(3);
+
+            var m = _([1]);
+            var f = function (x) {
+                return _(['f(' + x + ')']);
+            };
+            var g = function (x) {
+                return _(['g(' + x + ')']);
+            };
+
+            _([
+                m.fork()[fl.chain](f)[fl.chain](g).collect(),
+                m.observe()[fl.chain](function (x) {
+                    return f(x)[fl.chain](g);
+                }).collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, ['g(f(1))']);
+                    test.same(rights, ['g(f(1))']);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
+    }
+};
+
 exports.pluck = function (test) {
     var a = _([
         {type: 'blogpost', title: 'foo'},

--- a/test/test.js
+++ b/test/test.js
@@ -4269,6 +4269,31 @@ exports.concat = function (test) {
     test.done();
 };
 
+exports['concat - semigroup'] = {
+    'associativity': {
+        'a.concat(b).concat(c) is equivalent to a.concat(b.concat(c))': function (test) {
+            test.expect(3);
+
+            var a = _([1]);
+            var b = _([2]);
+            var c = _([3]);
+
+            _([
+                a.fork()[fl.concat](b.fork())[fl.concat](c.fork()).collect(),
+                a.observe()[fl.concat](b.observe()[fl.concat](c.observe())).collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, [1, 2, 3]);
+                    test.same(rights, [1, 2, 3]);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
+    }
+};
+
 exports['concat - noValueOnError'] = noValueOnErrorTest(_.concat([1]), [1]);
 
 exports['concat - ArrayStream'] = function (test) {

--- a/test/test.js
+++ b/test/test.js
@@ -3555,6 +3555,54 @@ exports.otherwise = function (test) {
     test.done();
 };
 
+exports['otherwise - alt'] = {
+    'associativity': {
+        'a.alt(b).alt(c) is equivalent to a.alt(b.alt(c))': function (test) {
+            test.expect(3);
+
+            var a = _([]);
+            var b = _([]);
+            var c = _([1]);
+
+            _([
+                a.fork()[fl.alt](b.fork())[fl.alt](c.fork()).collect(),
+                a.observe()[fl.alt](b.observe()[fl.alt](c.observe())).collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, [1]);
+                    test.same(rights, [1]);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
+    },
+    'distributivity': {
+        'a.alt(b).map(f) is equivalent to a.map(f).alt(b.map(f))': function (test) {
+            test.expect(3);
+
+            var a = _([]);
+            var b = _([1]);
+            var f = function (x) {
+                return 'f(' + x + ')';
+            };
+
+            _([
+                a.fork()[fl.alt](b.fork())[fl.map](f).collect(),
+                a.observe()[fl.map](f)[fl.alt](b.observe()[fl.map](f)).collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, ['f(1)']);
+                    test.same(rights, ['f(1)']);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
+    },
+};
 
 exports['otherwise - noValueOnError'] = noValueOnErrorTest(_.otherwise(_([])));
 

--- a/test/test.js
+++ b/test/test.js
@@ -1621,6 +1621,76 @@ exports.of = {
                 test.same(result, 1);
                 test.done();
             });
+    },
+    'applicative': {
+        'identity': {
+            'v.ap(A.of(x => x)) is equivalent to v': function (test) {
+                test.expect(3);
+                var v = _([1]);
+                var f = function (x) {
+                    return x;
+                };
+
+                _([
+                    v.fork()[fl.ap](_[fl.of](f)),
+                    v.observe(),
+                ])
+                    .sequence()
+                    .apply(function (lefts, rights) {
+                        test.same(lefts, [1]);
+                        test.same(rights, [1]);
+                        test.same(lefts, rights);
+                    });
+
+                test.done();
+            }
+        },
+        'homomorphism': {
+            'A.of(x).ap(A.of(f)) is equivalent to A.of(f(x))': function (test) {
+                test.expect(3);
+                var f = function (x) {
+                    return 'f(' + x + ')';
+                };
+
+                _([
+                    _[fl.of](1)[fl.ap](_[fl.of](f)).collect(),
+                    _[fl.of](f(1)).collect(),
+                ])
+                    .sequence()
+                    .apply(function (lefts, rights) {
+                        test.same(lefts, ['f(1)']);
+                        test.same(rights, ['f(1)']);
+                        test.same(lefts, rights);
+                    });
+
+                test.done();
+            }
+        },
+        'interchange': {
+            'A.of(y).ap(u) is equivalent to u.ap(A.of(f => f(y)))': function (test) {
+                test.expect(3);
+                var y = _([1]);
+                var u = function (x) {
+                    return 'f(' + x + ')';
+                };
+                var f = function (x) {
+                    return 'f(' + x + ')';
+                };
+
+                _([
+                    _[fl.of](y)[fl.ap](u).collect(),
+                    u[fl.ap](_[fl.of](f)).collect(),
+                ])
+                    .sequence()
+                    .apply(function (lefts, rights) {
+                        test.same(lefts, ['f(1)']);
+                        test.same(rights, ['f(1)']);
+                        test.same(lefts, rights);
+                    });
+
+                test.done();
+            }
+        },
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,8 @@ var _, EventEmitter = require('events').EventEmitter,
     Promise = RSVP.Promise,
     transducers = require('transducers-js'),
     bluebird = require('bluebird'),
-    runTask = require('orchestrator/lib/runTask');
+    runTask = require('orchestrator/lib/runTask'),
+    fl = require('fantasy-land');
 
 if (global.highland != null) {
     _ = global.highland;
@@ -4782,19 +4783,72 @@ exports['nfcall - parallel result ordering'] = function (test) {
     });
 };
 
-exports.map = function (test) {
-    test.expect(2);
-    function doubled(x) {
-        return x * 2;
+exports.map = {
+    'map': function (test) {
+        test.expect(2);
+        function doubled(x) {
+            return x * 2;
+        }
+        _.map(doubled, [1, 2, 3, 4]).toArray(function (xs) {
+            test.same(xs, [2, 4, 6, 8]);
+        });
+        // partial application
+        _.map(doubled)([1, 2, 3, 4]).toArray(function (xs) {
+            test.same(xs, [2, 4, 6, 8]);
+        });
+        test.done();
+    },
+    'functor': {
+        'identity': {
+            'u.map(a => a) is equivalent to u': function (test) {
+                test.expect(3);
+                var u = _([1]);
+                var f = function (x) {
+                    return x;
+                };
+
+                _([
+                    u.fork()[fl.map](f).collect(),
+                    u.observe().collect(),
+                ])
+                    .sequence()
+                    .apply(function (lefts, rights) {
+                        test.same(lefts, [1]);
+                        test.same(rights, [1]);
+                        test.same(lefts, rights);
+                    });
+
+                test.done();
+            }
+        },
+        'composition': {
+            'u.map(x => f(g(x))) is equivalent to u.map(g).map(f)': function (test) {
+                test.expect(3);
+                var u = _([1]);
+                var f = function (x) {
+                    return 'f(' + x + ')';
+                };
+                var g = function (x) {
+                    return 'g(' + x + ')';
+                };
+
+                _([
+                    u.fork()[fl.map](function (x) {
+                        return f(g(x));
+                    }).collect(),
+                    u.observe()[fl.map](g)[fl.map](f).collect(),
+                ])
+                    .sequence()
+                    .apply(function (lefts, rights) {
+                        test.same(lefts, ['f(g(1))']);
+                        test.same(rights, ['f(g(1))']);
+                        test.same(lefts, rights);
+                    });
+
+                test.done();
+            }
+        }
     }
-    _.map(doubled, [1, 2, 3, 4]).toArray(function (xs) {
-        test.same(xs, [2, 4, 6, 8]);
-    });
-    // partial application
-    _.map(doubled)([1, 2, 3, 4]).toArray(function (xs) {
-        test.same(xs, [2, 4, 6, 8]);
-    });
-    test.done();
 };
 
 exports['map - noValueOnError'] = noValueOnErrorTest(_.map(function (x) { return x; }));

--- a/test/test.js
+++ b/test/test.js
@@ -5420,6 +5420,84 @@ exports.filter = function (test) {
     test.done();
 };
 
+exports['filter - filterable'] = {
+    'distributivity': {
+        'v.filter(x => p(x) && q(x)) is equivalent to v.filter(p).filter(q)': function (test) {
+            test.expect(3);
+
+            var v = _([1, 2]);
+            var p = function (x) {
+                return x > 0;
+            };
+            var q = function (x) {
+                return x < 2;
+            };
+
+            _([
+                v.fork()[fl.filter](function (x) {
+                    return p(x) && q(x);
+                }).collect(),
+                v.observe()[fl.filter](p)[fl.filter](q).collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, [1]);
+                    test.same(rights, [1]);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
+    },
+    'identity': {
+        'v.filter(x => true) is equivalent to v': function (test) {
+            test.expect(3);
+
+            var v = _([1, 2]);
+            var p = function (x) {
+                return true;
+            };
+
+            _([
+                v.fork()[fl.filter](p).collect(),
+                v.observe().collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, [1, 2]);
+                    test.same(rights, [1, 2]);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
+    },
+    'annihilation': {
+        'v.filter(x => false) is equivalent to w.filter(x => false) if v and w are values of the same Filterable': function (test) {
+            test.expect(3);
+
+            var v = _([1, 2]);
+            var w = _([1, 2]);
+            var p = function (x) {
+                return false;
+            };
+
+            _([
+                v[fl.filter](p).collect(),
+                w[fl.filter](p).collect(),
+            ])
+                .sequence()
+                .apply(function (lefts, rights) {
+                    test.same(lefts, []);
+                    test.same(rights, []);
+                    test.same(lefts, rights);
+                });
+
+            test.done();
+        }
+    },
+};
+
 exports['filter - noValueOnError'] = noValueOnErrorTest(_.filter(function (x) { return true; }));
 
 exports['filter - onDestroy'] = onDestroyTest(_.filter(function (x) { return true; }), 1);


### PR DESCRIPTION
This PR is to address #656 

This currently includes mappings and tests for the following types:
* `fantasy-land/of` => `_.of` (the tests require `ap` from #643)
* `fantasy-land/map` => `_.map`
* `fantasy-land/chain` => `_.flatMap`
* `fantasy-land/filter` => `_.filter`
* `fantasy-land/alt` => `_.otherwise`
* `fantasy-land/concat` => `_.concat`

Additionally, the following mappings can be added after #657:
* `fantasy-land/empty` => `_.empty`
* `fantasy-land/zero` => `_.empty`