### PR TITLE
Subscribe method with separated out nil\global file

### DIFF
--- a/lib/createObserver.js
+++ b/lib/createObserver.js
@@ -1,0 +1,55 @@
+var isFunction = require('./isFunction');
+
+/**
+ * Coerce observer callbacks into observer object or return observer object
+ * if already created. Will throw an error if both an object and callback args
+ * are provided.
+ *
+ * @id createObserver
+ * @param {function|object} onNext Function to receive new values or observer
+ * @param {function} [onError] Optional callback to receive errors.
+ * @param {function} [onComplete] Optional callback when stream completes
+ * @return {object} Observer object with next, error, and complete methods
+ * @private
+ *
+ * createObserver(
+ *     function (x) { console.log(x); },
+ *     function (err) { console.error(err); },
+ *     function () { console.log('done'); }
+ * )
+ *
+ * createObserver(
+ *     null,
+ *     null,
+ *     function () { console.log('done'); }
+ * )
+ *
+ * createObserver({
+ *     next: function (x) { console.log(x); },
+ *     error: function (err) { console.error(err); },
+ *     complete: function () { console.log('done'); }
+ * })
+ */
+function createObserver (onNext, onError, onComplete) {
+    var isObserver = onNext && !isFunction(onNext) && typeof onNext === 'object';
+
+    // ensure if we have an observer that we don't also have callbacks. Users
+    // must choose one.
+    if (isObserver && (onError || onComplete)) {
+        throw new Error('Subscribe requires either an observer object or optional callbacks.');
+    }
+
+    // onNext is actually an observer
+    if (isObserver) {
+        return onNext;
+    }
+
+    // Otherwise create an observer object
+    return {
+        next: onNext,
+        error: onError,
+        complete: onComplete,
+    };
+}
+
+module.exports = createObserver;

--- a/lib/global.js
+++ b/lib/global.js
@@ -1,27 +1,22 @@
 /**
- * Resolve
- *
  * Return a global context upon which to install Highland globals. Takes a
  * default namespace to use if both the node global and browser window
  * namespace cannot be found.
  *
- * @param {object} defaultNamespace - Default namespace if global not found
  * @returns {object} Global namespace context
  */
 
-function resolveGlobalNS (defaultNamespace) {
-    // Use the nodejs global namespace
-    if (typeof global !== 'undefined') {
-        return global;
-    }
-    // Use the browser window namespace
-    else if (typeof window !== 'undefined') {
-        return window;
-    }
-
-    // If neither the global namespace or browser namespace is avaiable
-    // return this module as the default context.
-    return defaultNamespace;
+// Use the nodejs global namespace
+if (typeof global !== 'undefined') {
+    module.exports = global;
+}
+// Use the browser window namespace
+else if (typeof window !== 'undefined') {
+    module.exports = window;
+}
+// If neither the global namespace or browser namespace is avaiable
+// Use this module as the default context
+else {
+    module.exports = this;
 }
 
-module.exports = resolveGlobalNS();

--- a/lib/global.js
+++ b/lib/global.js
@@ -1,0 +1,27 @@
+/**
+ * Resolve
+ *
+ * Return a global context upon which to install Highland globals. Takes a
+ * default namespace to use if both the node global and browser window
+ * namespace cannot be found.
+ *
+ * @param {object} defaultNamespace - Default namespace if global not found
+ * @returns {object} Global namespace context
+ */
+
+function resolveGlobalNS (defaultNamespace) {
+    // Use the nodejs global namespace
+    if (typeof global !== 'undefined') {
+        return global;
+    }
+    // Use the browser window namespace
+    else if (typeof window !== 'undefined') {
+        return window;
+    }
+
+    // If neither the global namespace or browser namespace is avaiable
+    // return this module as the default context.
+    return defaultNamespace;
+}
+
+module.exports = resolveGlobalNS();

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,13 +22,7 @@ var slice = Array.prototype.slice;
 var hasOwn = Object.prototype.hasOwnProperty;
 
 // Set up the global object.
-var _global = this;
-if (typeof global !== 'undefined') {
-    _global = global;
-}
-else if (typeof window !== 'undefined') {
-    _global = window;
-}
+var _global = require('./global');
 
 // ES5 detected value, used for switch between ES5 and ES3 code
 var isES5 = (function () {
@@ -383,10 +377,7 @@ else {
 
 // set up a global nil object in cases where you have multiple Highland
 // instances installed (often via npm)
-if (!_global.nil) {
-    _global.nil = {};
-}
-var nil = _.nil = _global.nil;
+var nil = _.nil = require('./nil');
 
 /**
  * Transforms a function with specific arity (all arguments must be
@@ -2211,47 +2202,9 @@ function createObserver (onNext, onError, onComplete) {
  */
 
 addMethod('subscribe', function (onNext, onError, onComplete) {
-    var self = this;
     var observer = createObserver(onNext, onError, onComplete);
 
-    // Don't let users subscribe to an already completed stream
-    if (self.ended) {
-        if (observer.error) {
-            observer.error(new Error('Subscribe called on an already completed stream.'));
-        }
-
-        var closedSubscription = new ObservableSubscription();
-        closedSubscription._cleanup();
-        return closedSubscription;
-    }
-
-    var source = self.fork();
-    var subscription = new ObservableSubscription(source);
-    var consumer = source.consume(function (err, x, push, next) {
-        if (err) {
-            push(null, nil);
-            if (observer.error) {
-                observer.error(err);
-            }
-            subscription._cleanup();
-        }
-        else if (x === nil) {
-            if (observer.complete) {
-                observer.complete();
-            }
-            subscription._cleanup();
-        }
-        else {
-            if (observer.next) {
-                observer.next(x);
-            }
-            next();
-        }
-    });
-
-    consumer.resume();
-
-    return subscription;
+    return new ObservableSubscription(this, observer);
 });
 
 /*

--- a/lib/index.js
+++ b/lib/index.js
@@ -2153,21 +2153,11 @@ function createObserver (onNext, onError, onComplete) {
     }
 
     // Otherwise create an observer object
-    var observer = {};
-
-    if (_.isFunction(onNext)) {
-        observer.next = onNext;
-    }
-
-    if (_.isFunction(onError)) {
-        observer.error = onError;
-    }
-
-    if (_.isFunction(onComplete)) {
-        observer.complete = onComplete;
-    }
-
-    return observer;
+    return {
+        next: onNext,
+        error: onError,
+        complete: onComplete,
+    };
 }
 
 /**
@@ -2179,7 +2169,7 @@ function createObserver (onNext, onError, onComplete) {
  * Implements the Observable subscribe functionality as defined by the spec:
  * https://tc39.github.io/proposal-observable/#observable-prototype-subscribe
  *
- * @id toPromise
+ * @id subscribe
  * @section Consumption
  * @name Stream.subscribe(onNext, onError, onComplete)
  * @param {Function|object|null} onNext - Handler for next value or observer
@@ -2220,28 +2210,28 @@ function createObserver (onNext, onError, onComplete) {
 
 addMethod('subscribe', function (onNext, onError, onComplete) {
     var self = this;
+    var observer = createObserver(onNext, onError, onComplete);
 
     // Don't let users subscribe to an already completed stream
-    if (self.ended) {
-        throw new Error('Subscribe called on an already completed stream.');
+    if (self.ended && observer.error) {
+        observer.error(new Error('Subscribe called on an already completed stream.'));
     }
 
-    var observer = createObserver(onNext, onError, onComplete);
     var subscription = self.fork().consume(function (err, x, push, next) {
         if (err) {
             push(null, nil);
 
-            if (_.isFunction(observer.error)) {
+            if (observer.error) {
                 observer.error(err);
             }
         }
         else if (x === nil) {
-            if (_.isFunction(observer.complete)) {
+            if (observer.complete) {
                 observer.complete();
             }
         }
         else {
-            if (_.isFunction(observer.next)) {
+            if (observer.next) {
                 observer.next(x);
             }
             next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -2109,21 +2109,82 @@ addMethod('toPromise', function (PromiseCtor) {
 });
 
 /**
+ * Coerce observer callbacks into observer object or return observer object
+ * if already created. Will throw an error if both an object and callback args
+ * are provided.
+ *
+ * @id createObserver
+ * @param {function|object} onNext Function to receive new values or observer
+ * @param {function} [onError] Optional callback to receive errors.
+ * @param {function} [onComplete] Optional callback when stream completes
+ * @return {object} Observer object with next, error, and complete methods
+ * @private
+ *
+ * createObserver(
+ *     function (x) { console.log(x); },
+ *     function (err) { console.error(err); },
+ *     function () { console.log('done'); }
+ * )
+ *
+ * createObserver(
+ *     null,
+ *     null,
+ *     function () { console.log('done'); }
+ * )
+ *
+ * createObserver({
+ *     next: function (x) { console.log(x); },
+ *     error: function (err) { console.error(err); },
+ *     complete: function () { console.log('done'); }
+ * })
+ */
+function createObserver (onNext, onError, onComplete) {
+    var isObserver = onNext && !onNext.call && typeof onNext === 'object';
+
+    // ensure if we have an observer that we don't also have callbacks. Users
+    // must choose one.
+    if (isObserver && (onError || onComplete)) {
+        throw new Error('Subscribe requires either an observer object or optional callbacks.');
+    }
+
+    // onNext is actually an observer
+    if (isObserver) {
+        return onNext;
+    }
+
+    // Otherwise create an observer object
+    var observer = {};
+
+    if (_.isFunction(onNext)) {
+        observer.next = onNext;
+    }
+
+    if (_.isFunction(onError)) {
+        observer.error = onError;
+    }
+
+    if (_.isFunction(onComplete)) {
+        observer.complete = onComplete;
+    }
+
+    return observer;
+}
+
+/**
  * Consumes values using the Observable subscribe signature.
  *
- * Some existing libraries like Gulp v4 can automatically handle return values
- * of observables by checking for a subscribe function. This method adds
- * compatability for those use cases by providing the same subscribe method
- * used by libraries like RxJS.
+ * Implements the Observable subscribe functionality as defined by the spec:
+ * https://tc39.github.io/proposal-observable/#observable-prototype-subscribe
  *
  * @id toPromise
  * @section Consumption
  * @name Stream.subscribe(onNext, onError, onComplete)
- * @param {Function|null} onNext - Handler function for each value.
+ * @param {Function|object|null} onNext - Handler for next value or observer
  * @param {Function|null} onError - Handler function for errors.
  * @param {Function|null} onCompleted - Handler Function when stream is done.
  * @api public
  *
+ *  // with callbacks
  * _([1, 2, 3, 4]).subscribe(
  *     function onNext (x) {
  *         // Called for each value that comes downstream
@@ -2136,33 +2197,61 @@ addMethod('toPromise', function (PromiseCtor) {
  *     function onComplete () {
  *         // Receives no arguments
  *         // Called only once when stream is completed.
- *         console.log('Completed the page.');
+ *         console.log('Completed!');
  *     }
  * );
+ *
+ * // with an observer
+ * _[1, 2, 3, 4]).subscribe({
+ *     next (x) {
+ *         console.log('Received next value', x);
+ *     },
+ *     error (err) {
+ *         console.error('An error occurred upstream', err);
+ *     },
+ *     complete () {
+ *         console.log('Completed!')
+ *     }
+ * });
  */
 
 addMethod('subscribe', function (onNext, onError, onComplete) {
     var self = this;
-    return self.consume(function (err, x, push, next) {
+
+    // Don't let users subscribe to an already completed stream
+    if (self._nil_pushed) {
+        throw new Error('Subscribe called on an already completed stream.');
+    }
+
+    var observer = createObserver(onNext, onError, onComplete);
+    var subscription = self.fork().consume(function (err, x, push, next) {
         if (err) {
             push(null, nil);
 
-            if (_.isFunction(onError)) {
-                onError(err);
+            if (_.isFunction(observer.error)) {
+                observer.error(err);
             }
         }
         else if (x === nil) {
-            if (_.isFunction(onComplete)) {
-                onComplete();
+            if (_.isFunction(observer.complete)) {
+                observer.complete();
             }
         }
         else {
-            if (_.isFunction(onNext)) {
-                onNext(x);
+            if (_.isFunction(observer.next)) {
+                observer.next(x);
             }
             next();
         }
-    }).resume();
+    });
+
+    subscription.resume();
+
+    return {
+        unsubscribe: function () {
+            subscription.destroy();
+        },
+    };
 });
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -2218,21 +2218,21 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
         observer.error(new Error('Subscribe called on an already completed stream.'));
     }
 
-    var subscription = ObservableSubscription.create();
-    var source = self.fork().consume(function (err, x, push, next) {
+    var source = self.fork();
+    var subscription = new ObservableSubscription(source);
+    var consumer = source.consume(function (err, x, push, next) {
         if (err) {
             push(null, nil);
-
             if (observer.error) {
                 observer.error(err);
             }
-            ObservableSubscription.cleanup(subscription);
+            subscription._cleanup();
         }
         else if (x === nil) {
             if (observer.complete) {
                 observer.complete();
             }
-            ObservableSubscription.cleanup(subscription);
+            subscription._cleanup();
         }
         else {
             if (observer.next) {
@@ -2241,9 +2241,8 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
             next();
         }
     });
-    subscription.source = source;
 
-    source.resume();
+    consumer.resume();
 
     return subscription;
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -2254,10 +2254,18 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
     };
 });
 
+/*
+ * Create a variable we can use as a dynamic method name depending on the
+ * environment.
+ *
+ * If Symbols are available get the observable symbol. Otherwise use the a
+ * fallback string.
+ * https://tc39.github.io/proposal-observable/#observable-prototype-@@observable
+ *
+ * Source taken from RxJS
+ * https://github.com/ReactiveX/rxjs/commit/4a5aaafc99825ae9b61e410bc0b5e86c7ae75837#diff-d26bc4881b94c82f3c0ae7d3914e9577R13
+ */
 /* eslint-disable no-undef */
-// If Symbols are available get the observable symbol. Otherwise use the a
-// fallback string.
-// https://tc39.github.io/proposal-observable/#observable-prototype-@@observable
 var observable = typeof Symbol === 'function' && Symbol.observable || '@@observable';
 /* eslint-enable no-undef */
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var Decoder = require('string_decoder').StringDecoder;
 var IntMap = require('./intMap');
 var Queue = require('./queue');
 var ReadableProxy = require('./readableProxy');
+var ObservableSubscription = require('./observableSubscription');
 
 // Create quick slice reference variable for speed
 var slice = Array.prototype.slice;
@@ -2217,7 +2218,7 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
         observer.error(new Error('Subscribe called on an already completed stream.'));
     }
 
-    var subscription = self.fork().consume(function (err, x, push, next) {
+    var source = self.fork().consume(function (err, x, push, next) {
         if (err) {
             push(null, nil);
 
@@ -2238,13 +2239,9 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
         }
     });
 
-    subscription.resume();
+    source.resume();
 
-    return {
-        unsubscribe: function () {
-            subscription.destroy();
-        },
-    };
+    return ObservableSubscription.create(source);
 });
 
 /*

--- a/lib/index.js
+++ b/lib/index.js
@@ -2139,7 +2139,7 @@ addMethod('toPromise', function (PromiseCtor) {
  * })
  */
 function createObserver (onNext, onError, onComplete) {
-    var isObserver = onNext && !onNext.call && typeof onNext === 'object';
+    var isObserver = onNext && !_.isFunction(onNext) && typeof onNext === 'object';
 
     // ensure if we have an observer that we don't also have callbacks. Users
     // must choose one.
@@ -2171,7 +2171,10 @@ function createObserver (onNext, onError, onComplete) {
 }
 
 /**
- * Consumes values using the Observable subscribe signature.
+ * Consumes values using the Observable subscribe signature. Unlike other
+ * consumption methods, subscribe can be called multiple times. Each
+ * subscription will receive the current value before receiving the next value.
+ * Subscribing to an already consumed stream will result in an error.
  *
  * Implements the Observable subscribe functionality as defined by the spec:
  * https://tc39.github.io/proposal-observable/#observable-prototype-subscribe
@@ -2184,7 +2187,7 @@ function createObserver (onNext, onError, onComplete) {
  * @param {Function|null} onCompleted - Handler Function when stream is done.
  * @api public
  *
- *  // with callbacks
+ * // with callbacks
  * _([1, 2, 3, 4]).subscribe(
  *     function onNext (x) {
  *         // Called for each value that comes downstream
@@ -2202,7 +2205,7 @@ function createObserver (onNext, onError, onComplete) {
  * );
  *
  * // with an observer
- * _[1, 2, 3, 4]).subscribe({
+ * _([1, 2, 3, 4]).subscribe({
  *     next (x) {
  *         console.log('Received next value', x);
  *     },
@@ -2219,7 +2222,7 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
     var self = this;
 
     // Don't let users subscribe to an already completed stream
-    if (self._nil_pushed) {
+    if (self.ended) {
         throw new Error('Subscribe called on an already completed stream.');
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2176,6 +2176,7 @@ function createObserver (onNext, onError, onComplete) {
  * @param {Function|object|null} onNext - Handler for next value or observer
  * @param {Function|null} onError - Handler function for errors.
  * @param {Function|null} onCompleted - Handler Function when stream is done.
+ * @returns {ObservableSubscription - Subscription with unsubscribed method
  * @api public
  *
  * // with callbacks
@@ -2216,7 +2217,10 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
     // Don't let users subscribe to an already completed stream
     if (self.ended && observer.error) {
         observer.error(new Error('Subscribe called on an already completed stream.'));
-        return self;
+        var closedSubscription = new ObservableSubscription();
+
+        closedSubscription.closed = true;
+        return closedSubscription;
     }
 
     var source = self.fork();

--- a/lib/index.js
+++ b/lib/index.js
@@ -2108,6 +2108,62 @@ addMethod('toPromise', function (PromiseCtor) {
     });
 });
 
+/**
+ * Consumes values using the Observable subscribe signature.
+ *
+ * Some existing libraries like Gulp v4 can automatically handle return values
+ * of observables by checking for a subscribe function. This method adds
+ * compatability for those use cases by providing the same subscribe method
+ * used by libraries like RxJS.
+ *
+ * @id toPromise
+ * @section Consumption
+ * @name Stream.subscribe(onNext, onError, onComplete)
+ * @param {Function|null} onNext - Handler function for each value.
+ * @param {Function|null} onError - Handler function for errors.
+ * @param {Function|null} onCompleted - Handler Function when stream is done.
+ * @api public
+ *
+ * _([1, 2, 3, 4]).subscribe(
+ *     function onNext (x) {
+ *         // Called for each value that comes downstream
+ *         console.log('Received onNext value', x);
+ *     },
+ *     function onError (err) {
+ *         // Called one time with error or zero if no errors occur upstream
+ *         console.error('Single highland stream error', err);
+ *     },
+ *     function onComplete () {
+ *         // Receives no arguments
+ *         // Called only once when stream is completed.
+ *         console.log('Completed the page.');
+ *     }
+ * );
+ */
+
+addMethod('subscribe', function (onNext, onError, onComplete) {
+    var self = this;
+    return self.consume(function (err, x, push, next) {
+        if (err) {
+            push(null, nil);
+
+            if (_.isFunction(onError)) {
+                onError(err);
+            }
+        }
+        else if (x === nil) {
+            if (_.isFunction(onComplete)) {
+                onComplete();
+            }
+        }
+        else {
+            if (_.isFunction(onNext)) {
+                onNext(x);
+            }
+            next();
+        }
+    }).resume();
+});
 
 /**
  * Converts the stream to a node Readable Stream for use in methods

--- a/lib/index.js
+++ b/lib/index.js
@@ -2218,6 +2218,7 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
         observer.error(new Error('Subscribe called on an already completed stream.'));
     }
 
+    var subscription = ObservableSubscription.create();
     var source = self.fork().consume(function (err, x, push, next) {
         if (err) {
             push(null, nil);
@@ -2225,11 +2226,13 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
             if (observer.error) {
                 observer.error(err);
             }
+            ObservableSubscription.cleanup(subscription);
         }
         else if (x === nil) {
             if (observer.complete) {
                 observer.complete();
             }
+            ObservableSubscription.cleanup(subscription);
         }
         else {
             if (observer.next) {
@@ -2238,10 +2241,11 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
             next();
         }
     });
+    subscription.source = source;
 
     source.resume();
 
-    return ObservableSubscription.create(source);
+    return subscription;
 });
 
 /*

--- a/lib/index.js
+++ b/lib/index.js
@@ -2176,7 +2176,7 @@ function createObserver (onNext, onError, onComplete) {
  * @param {Function|object|null} onNext - Handler for next value or observer
  * @param {Function|null} onError - Handler function for errors.
  * @param {Function|null} onCompleted - Handler Function when stream is done.
- * @returns {ObservableSubscription - Subscription with unsubscribed method
+ * @returns {ObservableSubscription} - Subscription with unsubscribed method
  * @api public
  *
  * // with callbacks
@@ -2215,11 +2215,13 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
     var observer = createObserver(onNext, onError, onComplete);
 
     // Don't let users subscribe to an already completed stream
-    if (self.ended && observer.error) {
-        observer.error(new Error('Subscribe called on an already completed stream.'));
-        var closedSubscription = new ObservableSubscription();
+    if (self.ended) {
+        if (observer.error) {
+            observer.error(new Error('Subscribe called on an already completed stream.'));
+        }
 
-        closedSubscription.closed = true;
+        var closedSubscription = new ObservableSubscription();
+        closedSubscription._cleanup();
         return closedSubscription;
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2216,6 +2216,7 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
     // Don't let users subscribe to an already completed stream
     if (self.ended && observer.error) {
         observer.error(new Error('Subscribe called on an already completed stream.'));
+        return;
     }
 
     var source = self.fork();

--- a/lib/index.js
+++ b/lib/index.js
@@ -2254,6 +2254,35 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
     };
 });
 
+/* eslint-disable no-undef */
+// If Symbols are available get the observable symbol. Otherwise use the a
+// fallback string.
+// https://tc39.github.io/proposal-observable/#observable-prototype-@@observable
+var observable = typeof Symbol === 'function' && Symbol.observable || '@@observable';
+/* eslint-enable no-undef */
+
+/**
+ * Returns an Observable spec-compliant instance (itself) that has a subscribe
+ * method and a Symbol.observable method. If Symbol is not available in the
+ * current environment it defaults to '@@observable'. Used by other tools and
+ * libraries that want to get an observable spec compliant stream interface.
+ *
+ * https://tc39.github.io/proposal-observable/#observable-prototype-@@observable
+ *
+ * @id Symbol.observable
+ * @section Consumption
+ * @name Symbol.observable
+ * @api public
+ *
+ * _([1, 2, 3])[Symbol.observable || "@@observable"]().subscribe(x => {
+ *     console.log("Received value", x);
+ * });
+ */
+
+addMethod(observable, function () {
+    return this;
+});
+
 /**
  * Converts the stream to a node Readable Stream for use in methods
  * or pipes that depend on the native stream type.

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,10 +12,12 @@ var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 var Decoder = require('string_decoder').StringDecoder;
 
+var createObserver = require('./createObserver');
+var isFunction = require('./isFunction');
 var IntMap = require('./intMap');
+var ObservableSubscription = require('./observableSubscription');
 var Queue = require('./queue');
 var ReadableProxy = require('./readableProxy');
-var ObservableSubscription = require('./observableSubscription');
 
 // Create quick slice reference variable for speed
 var slice = Array.prototype.slice;
@@ -312,9 +314,7 @@ _.isUndefined = function (x) {
     return typeof x === 'undefined';
 };
 
-_.isFunction = function (x) {
-    return typeof x === 'function';
-};
+_.isFunction = isFunction;
 
 _.isObject = function (x) {
     return typeof x === 'object' && x !== null;
@@ -2100,57 +2100,6 @@ addMethod('toPromise', function (PromiseCtor) {
     });
 });
 
-/**
- * Coerce observer callbacks into observer object or return observer object
- * if already created. Will throw an error if both an object and callback args
- * are provided.
- *
- * @id createObserver
- * @param {function|object} onNext Function to receive new values or observer
- * @param {function} [onError] Optional callback to receive errors.
- * @param {function} [onComplete] Optional callback when stream completes
- * @return {object} Observer object with next, error, and complete methods
- * @private
- *
- * createObserver(
- *     function (x) { console.log(x); },
- *     function (err) { console.error(err); },
- *     function () { console.log('done'); }
- * )
- *
- * createObserver(
- *     null,
- *     null,
- *     function () { console.log('done'); }
- * )
- *
- * createObserver({
- *     next: function (x) { console.log(x); },
- *     error: function (err) { console.error(err); },
- *     complete: function () { console.log('done'); }
- * })
- */
-function createObserver (onNext, onError, onComplete) {
-    var isObserver = onNext && !_.isFunction(onNext) && typeof onNext === 'object';
-
-    // ensure if we have an observer that we don't also have callbacks. Users
-    // must choose one.
-    if (isObserver && (onError || onComplete)) {
-        throw new Error('Subscribe requires either an observer object or optional callbacks.');
-    }
-
-    // onNext is actually an observer
-    if (isObserver) {
-        return onNext;
-    }
-
-    // Otherwise create an observer object
-    return {
-        next: onNext,
-        error: onError,
-        complete: onComplete,
-    };
-}
 
 /**
  * Consumes values using the Observable subscribe signature. Unlike other

--- a/lib/index.js
+++ b/lib/index.js
@@ -2216,7 +2216,7 @@ addMethod('subscribe', function (onNext, onError, onComplete) {
     // Don't let users subscribe to an already completed stream
     if (self.ended && observer.error) {
         observer.error(new Error('Subscribe called on an already completed stream.'));
-        return;
+        return self;
     }
 
     var source = self.fork();

--- a/lib/isFunction.js
+++ b/lib/isFunction.js
@@ -1,0 +1,15 @@
+/**
+ * Is Function
+ * Predicate function takes a value and returns true if it is a function.
+ *
+ * @id isFunction
+ * @name isFunction(x)
+ * @param {any} x - Any value to test against
+ * @returns {bool} True if x is a function
+ */
+
+function isFunction (x) {
+    return typeof x === 'function';
+}
+
+module.exports = isFunction;

--- a/lib/isFunction.js
+++ b/lib/isFunction.js
@@ -1,5 +1,4 @@
 /**
- * Is Function
  * Predicate function takes a value and returns true if it is a function.
  *
  * @id isFunction

--- a/lib/nil.js
+++ b/lib/nil.js
@@ -14,4 +14,8 @@ var _global = require('./global');
  * nil it knows for sure the intention is to end the stream.
  */
 
-module.exports = _global.nil || {};
+if (!_global.nil) {
+    _global.nil = {};
+}
+
+module.exports = _global.nil;

--- a/lib/nil.js
+++ b/lib/nil.js
@@ -1,0 +1,17 @@
+var _global = require('./global');
+
+/*
+ * Resolve nil value from global namespace if it exists. This may happen when
+ * there are multiple versions of highland (like npm).
+ *
+ * nil is only equal to itself:
+ *
+ * nil === {}  => false
+ * nil === nil => true
+ *
+ * This property makes it valuable for determining a lack of input from a
+ * falsey value such as nil or undefined. When a highland stream encounters
+ * nil it knows for sure the intention is to end the stream.
+ */
+
+module.exports = _global.nil || {};

--- a/lib/observableSubscription.js
+++ b/lib/observableSubscription.js
@@ -3,6 +3,8 @@
  * An implementation of the TC39 Subscription object
  * https://tc39.github.io/proposal-observable/#subscription-objects
  *
+ * This class is intended for internal use only.
+ *
  * @id ObservableSubscription
  * @name ObservableSubscription
  * @param {stream} source - Highland stream to subscribe to
@@ -16,22 +18,56 @@ function ObservableSubscription (source) {
 
 // Static Methods
 
+/**
+ * Create
+ * Return an instance of an ObservableSubscription class
+ *
+ * @id ObservableSubscription.create(source)
+ * @name ObservableSubscription.create
+ * @param {stream} [source] - Optional highland stream source
+ * @returns {ObservableSubscription} A subscription that can be unsubscribed
+ * @api private
+ */
+
 ObservableSubscription.create = function create (source) {
     return new ObservableSubscription(source);
 };
+
+/**
+ * Cleanup
+ * Perform cleanup routine on a subscription. This can only be called once per
+ * subscription. Once its closed the subscription cannot be cleaned up again.
+ *
+ * Note: This relies heavily upon side-effects and mutates the subscription.
+ *
+ * @id ObservableSubscription.cleanup(subscription)
+ * @name ObservableSubscription.cleanup
+ * @param {ObservableSubscription} subscription - Subscription to cleanup
+ * @returns {undefined} Side-effectful function cleans up subscription
+ * @api private
+ */
 
 ObservableSubscription.cleanup = function cleanup (subscription) {
     if (subscription.closed) {
         return;
     }
-    subscription.source.destroy();
     subscription.source = null;
     subscription.closed = true;
 };
 
 // Instance Methods
 
+/**
+ * Unsubscribe
+ * Destroy the stream resources and cleanup the subscription.
+ * @id ObservableSubscription.prototype.unsubscribe()
+ * @name ObservableSubscription.prototype.unsubscribe()
+ * @returns {undefined} Side-effectful. Destroys stream and cleans up subscription.
+ * @api private
+ */
+
 ObservableSubscription.prototype.unsubscribe = function unsubscribe () {
+    this.source.destroy();
     ObservableSubscription.cleanup(this);
 };
 

--- a/lib/observableSubscription.js
+++ b/lib/observableSubscription.js
@@ -16,46 +16,29 @@ function ObservableSubscription (source) {
     this.closed = false;
 }
 
-// Static Methods
-
-/**
- * Create
- * Return an instance of an ObservableSubscription class
- *
- * @id ObservableSubscription.create(source)
- * @name ObservableSubscription.create
- * @param {stream} [source] - Optional highland stream source
- * @returns {ObservableSubscription} A subscription that can be unsubscribed
- * @api private
- */
-
-ObservableSubscription.create = function create (source) {
-    return new ObservableSubscription(source);
-};
+// Instance Methods
 
 /**
  * Cleanup
  * Perform cleanup routine on a subscription. This can only be called once per
  * subscription. Once its closed the subscription cannot be cleaned up again.
  *
- * Note: This relies heavily upon side-effects and mutates the subscription.
+ * Note: This relies heavily upon side-effects and mutates itself.
  *
- * @id ObservableSubscription.cleanup(subscription)
- * @name ObservableSubscription.cleanup
- * @param {ObservableSubscription} subscription - Subscription to cleanup
+ * @id ObservableSubscription.prototype._cleanup(subscription)
+ * @name ObservableSubscription.prototype._cleanup
  * @returns {undefined} Side-effectful function cleans up subscription
  * @api private
  */
 
-ObservableSubscription.cleanup = function cleanup (subscription) {
-    if (subscription.closed) {
+ObservableSubscription.prototype._cleanup = function cleanup () {
+    // Don't want to destroy\cleanup an already closed stream
+    if (this.closed) {
         return;
     }
-    subscription.source = null;
-    subscription.closed = true;
+    this.source = null;
+    this.closed = true;
 };
-
-// Instance Methods
 
 /**
  * Unsubscribe
@@ -67,8 +50,13 @@ ObservableSubscription.cleanup = function cleanup (subscription) {
  */
 
 ObservableSubscription.prototype.unsubscribe = function unsubscribe () {
+    // Don't want to destroy\cleanup an already closed stream
+    if (this.closed) {
+        return;
+    }
+
     this.source.destroy();
-    ObservableSubscription.cleanup(this);
+    this._cleanup();
 };
 
 module.exports = ObservableSubscription;

--- a/lib/observableSubscription.js
+++ b/lib/observableSubscription.js
@@ -12,7 +12,7 @@
  * @api private
  */
 function ObservableSubscription (source) {
-    this.source = source;
+    this._source = source;
     this.closed = false;
 }
 
@@ -36,7 +36,7 @@ ObservableSubscription.prototype._cleanup = function cleanup () {
     if (this.closed) {
         return;
     }
-    this.source = null;
+    this._source = null;
     this.closed = true;
 };
 
@@ -55,7 +55,7 @@ ObservableSubscription.prototype.unsubscribe = function unsubscribe () {
         return;
     }
 
-    this.source.destroy();
+    this._source.destroy();
     this._cleanup();
 };
 

--- a/lib/observableSubscription.js
+++ b/lib/observableSubscription.js
@@ -1,7 +1,6 @@
 var nil = require('./nil');
 
 /**
- * Observable Subscription
  * An implementation of the TC39 Subscription object
  * https://tc39.github.io/proposal-observable/#subscription-objects
  *
@@ -17,14 +16,13 @@ var nil = require('./nil');
  * @name ObservableSubscription
  * @param {stream} stream - Highland stream to subscribe to
  * @param {object} observer - Observer to publish from stream subscription
- * @returns {ObservableSubscription} A subscription object
  * @api private
  */
 function ObservableSubscription (stream, observer) {
     var self = this;
-    var source = stream.fork();
 
     // Set attributes
+    this._source = stream.fork();
     this.closed = false;
 
     // Don't let users subscribe to an already completed stream
@@ -35,11 +33,11 @@ function ObservableSubscription (stream, observer) {
 
         this._cleanup();
 
-        return this;
+        return;
     }
 
     // Consume the stream and emit data to the observer
-    this._source = source.consume(function (err, x, push, next) {
+    this._source = this._source.consume(function (err, x, push, next) {
         if (err) {
             push(null, nil);
             if (observer.error) {
@@ -67,7 +65,6 @@ function ObservableSubscription (stream, observer) {
 // Instance Methods
 
 /**
- * Cleanup
  * Perform cleanup routine on a subscription. This can only be called once per
  * subscription. Once its closed the subscription cannot be cleaned up again.
  *
@@ -89,7 +86,6 @@ ObservableSubscription.prototype._cleanup = function cleanup () {
 };
 
 /**
- * Unsubscribe
  * Destroy the stream resources and cleanup the subscription.
  * @id ObservableSubscription.prototype.unsubscribe()
  * @name ObservableSubscription.prototype.unsubscribe()

--- a/lib/observableSubscription.js
+++ b/lib/observableSubscription.js
@@ -1,0 +1,34 @@
+/**
+ * Observable Subscription
+ * An implementation of the TC39 Subscription object
+ * https://tc39.github.io/proposal-observable/#subscription-objects
+ *
+ * @id ObservableSubscription
+ * @name ObservableSubscription
+ * @param {stream} source - Highland stream to subscribe to
+ * arguments to the callback. Only valid if `source` is a String.
+ * @api private
+ */
+function ObservableSubscription (source) {
+    this.source = source;
+    this.closed = false;
+}
+
+// Static Methods
+
+ObservableSubscription.create = function create (source) {
+    return new ObservableSubscription(source);
+};
+
+// Instance Methods
+
+ObservableSubscription.prototype.unsubscribe = function unsubscribe () {
+    if (this.closed) {
+        return;
+    }
+    this.closed = true;
+    this.source.destroy();
+    this.source = null;
+};
+
+module.exports = ObservableSubscription;

--- a/lib/observableSubscription.js
+++ b/lib/observableSubscription.js
@@ -1,3 +1,5 @@
+var nil = require('./nil');
+
 /**
  * Observable Subscription
  * An implementation of the TC39 Subscription object
@@ -5,15 +7,61 @@
  *
  * This class is intended for internal use only.
  *
+ * Constructor takes a source highland stream, and an observer object with
+ * an optional next, error, and complete methods.
+ *
+ * Returns a subscription object with a closed boolean and unsubscribe
+ * method.
+ *
  * @id ObservableSubscription
  * @name ObservableSubscription
- * @param {stream} source - Highland stream to subscribe to
- * arguments to the callback. Only valid if `source` is a String.
+ * @param {stream} stream - Highland stream to subscribe to
+ * @param {object} observer - Observer to publish from stream subscription
+ * @returns {ObservableSubscription} A subscription object
  * @api private
  */
-function ObservableSubscription (source) {
-    this._source = source;
+function ObservableSubscription (stream, observer) {
+    var self = this;
+    var source = stream.fork();
+
+    // Set attributes
     this.closed = false;
+
+    // Don't let users subscribe to an already completed stream
+    if (stream.ended) {
+        if (observer.error) {
+            observer.error(new Error('Subscribe called on an already completed stream.'));
+        }
+
+        this._cleanup();
+
+        return this;
+    }
+
+    // Consume the stream and emit data to the observer
+    this._source = source.consume(function (err, x, push, next) {
+        if (err) {
+            push(null, nil);
+            if (observer.error) {
+                observer.error(err);
+            }
+            self._cleanup();
+        }
+        else if (x === nil) {
+            if (observer.complete) {
+                observer.complete();
+            }
+            self._cleanup();
+        }
+        else {
+            if (observer.next) {
+                observer.next(x);
+            }
+            next();
+        }
+    });
+
+    this._source.resume();
 }
 
 // Instance Methods

--- a/lib/observableSubscription.js
+++ b/lib/observableSubscription.js
@@ -20,15 +20,19 @@ ObservableSubscription.create = function create (source) {
     return new ObservableSubscription(source);
 };
 
+ObservableSubscription.cleanup = function cleanup (subscription) {
+    if (subscription.closed) {
+        return;
+    }
+    subscription.source.destroy();
+    subscription.source = null;
+    subscription.closed = true;
+};
+
 // Instance Methods
 
 ObservableSubscription.prototype.unsubscribe = function unsubscribe () {
-    if (this.closed) {
-        return;
-    }
-    this.closed = true;
-    this.source.destroy();
-    this.source = null;
+    ObservableSubscription.cleanup(this);
 };
 
 module.exports = ObservableSubscription;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "highland",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2538,7 +2538,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2953,7 +2954,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3009,6 +3011,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3052,12 +3055,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4959,6 +4964,7 @@
               "version": "0.1.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
@@ -6141,7 +6147,8 @@
             "longest": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "loose-envify": {
               "version": "1.3.1",

--- a/test/test.js
+++ b/test/test.js
@@ -2941,11 +2941,20 @@ exports.subscribe = {
         stream.end();
         test.done();
     },
-    'completed streams will throw an error': function (test) {
-        test.expect(1);
-        var stream = _();
+    'completed streams will not throw an error': function (test) {
+        test.expect(0);
+        var stream = _.empty();
 
-        stream.end();
+        stream.subscribe(function (x) {
+            throw new Error('I should not fire');
+        }, null, test.done);
+    },
+    'consumed streams will throw an error': function (test) {
+        test.expect(1);
+        var stream = _.empty();
+
+        stream.done(function () {});
+
         test.throws(function () {
             stream.subscribe(function (x) {
                 test.ok(x);

--- a/test/test.js
+++ b/test/test.js
@@ -2947,6 +2947,7 @@ exports.subscribe = {
             test.ok(true);
         });
         test.equal(sub.closed, true);
+        test.done();
     },
     'subscription is closed after error': function (test) {
         test.expect(2);
@@ -2954,15 +2955,19 @@ exports.subscribe = {
             test.ok(true);
         });
         test.equal(sub.closed, true);
+        test.done();
     },
     'subscription is closed after unsubscribe': function (test) {
         test.expect(3);
-        var sub = _([1]).subscribe(function (x) {
+        var stream = _();
+        var sub = stream.subscribe(function (x) {
             test.equal(x, 1);
         });
+        stream.write(1);
         test.equal(sub.closed, false);
         sub.unsubscribe();
         test.equal(sub.closed, true);
+        test.done();
     },
     'completed streams will not throw an error': function (test) {
         test.expect(0);
@@ -2978,7 +2983,7 @@ exports.subscribe = {
 
         stream.done(function () {});
 
-        stream.subscribe(null, null, function (err) {
+        stream.subscribe(null, function (err) {
             test.ok(err instanceof Error);
             test.done();
         });

--- a/test/test.js
+++ b/test/test.js
@@ -2955,12 +2955,10 @@ exports.subscribe = {
 
         stream.done(function () {});
 
-        test.throws(function () {
-            stream.subscribe(function (x) {
-                test.ok(x);
-            });
+        stream.subscribe(null, function (err) {
+            test.ok(err instanceof Error);
+            test.done();
         });
-        test.done();
     },
     'supports Symbol.observable or @@observable': function (test) {
         test.expect(1);

--- a/test/test.js
+++ b/test/test.js
@@ -2953,6 +2953,19 @@ exports.subscribe = {
         });
         test.done();
     },
+    'supports Symbol.observable or @@observable': function (test) {
+        test.expect(1);
+        /* eslint-disable no-undef */
+        var observable = typeof Symbol === 'function'
+            && Symbol.observable
+            || '@@observable';
+        /* eslint-enable no-undef */
+        _([1])[observable]()
+            .subscribe(function (x) {
+                test.equals(x, 1);
+                test.done();
+            });
+    },
 };
 
 exports['calls generator on read'] = function (test) {

--- a/test/test.js
+++ b/test/test.js
@@ -2811,6 +2811,83 @@ exports.toNodeStream = {
     },
 };
 
+exports.subscribe = {
+    'subscribe method exists and is a function': function (test) {
+        test.expect(1);
+        test.ok(_.isFunction(_.of(1).subscribe));
+        test.done();
+    },
+    'calls onNext handler with a single-value stream': function (test) {
+        test.expect(1);
+        _.of(1).subscribe(function (x) {
+            test.equal(x, 1);
+            test.done();
+        });
+    },
+    'calls onNext handler for an array stream': function (test) {
+        test.expect(3);
+        _([1, 2, 3]).subscribe(function (x) {
+            test.ok(x);
+
+            if (x === 3) {
+                test.done();
+            }
+        });
+    },
+    'calls onError handler for a single-error stream': function (test) {
+        test.expect(2);
+        _.fromError(new Error('test error')).subscribe(null, function (err) {
+            test.ok(err instanceof Error);
+            test.equal(err.message, 'test error');
+            test.done();
+        });
+    },
+    'calls onError once for a multi-error stream': function (test) {
+        test.expect(2);
+        var count = 0;
+        _([new Error('err1'), new Error('err2')])
+            .flatMap(_.fromError)
+            .subscribe(null, function (err) {
+                count++;
+                test.ok(err instanceof Error);
+                test.equal(err.message, 'err1');
+                test.done();
+            });
+    },
+    'calls onComplete handler for a single-value stream': function (test) {
+        test.expect(1);
+        _.of(1).subscribe(null, null, function (x) {
+            test.ok(typeof x === 'undefined');
+            test.done();
+        });
+    },
+    'calls onComplete handler once for a multi-value stream': function (test) {
+        test.expect(1);
+        _.of([1, 2, 3]).subscribe(null, null, function (x) {
+            test.ok(typeof x === 'undefined');
+            test.done();
+        });
+    },
+    'calls onComplete handler for an empty, complete stream': function (test) {
+        test.expect(1);
+        _.of([]).subscribe(null, null, function (x) {
+            test.ok(typeof x === 'undefined');
+            test.done();
+        });
+    },
+    'consumes the stream without any handlers': function (test) {
+        test.expect(3);
+        _([1, 2, 3])
+            .tap(function (x) {
+                test.ok(x);
+                if (x === 3) {
+                    test.done();
+                }
+            })
+            .subscribe();
+    },
+};
+
 exports['calls generator on read'] = function (test) {
     test.expect(5);
     var gen_calls = 0;

--- a/test/test.js
+++ b/test/test.js
@@ -2941,6 +2941,29 @@ exports.subscribe = {
         stream.end();
         test.done();
     },
+    'subscription is closed after complete': function (test) {
+        test.expect(2);
+        var sub = _([1]).subscribe(null, null, function (x) {
+            test.ok(true);
+        });
+        test.equal(sub.closed, true);
+    },
+    'subscription is closed after error': function (test) {
+        test.expect(2);
+        var sub = _.fromError(new Error('test error')).subscribe(null, function (x) {
+            test.ok(true);
+        });
+        test.equal(sub.closed, true);
+    },
+    'subscription is closed after unsubscribe': function (test) {
+        test.expect(3);
+        var sub = _([1]).subscribe(function (x) {
+            test.equal(x, 1);
+        });
+        test.equal(sub.closed, false);
+        sub.unsubscribe();
+        test.equal(sub.closed, true);
+    },
     'completed streams will not throw an error': function (test) {
         test.expect(0);
         var stream = _.empty();
@@ -2955,7 +2978,7 @@ exports.subscribe = {
 
         stream.done(function () {});
 
-        stream.subscribe(null, function (err) {
+        stream.subscribe(null, null, function (err) {
             test.ok(err instanceof Error);
             test.done();
         });


### PR DESCRIPTION
In reference to caolan/highland#672 this is the same solution with a couple of variations for experimentation and discussion:

1. Global namespace resolution was split up into a separate file
2. Nil resolution was split up into a separate file
3. Moved more of the subscribe consumption logic into the ObservableSubscription class
4. Moved createObserver into createObserver.js
5. Separated out isFunction.

What do you think @vqvu? 