### PR TITLE
add new .tapCollect() method

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -729,7 +729,7 @@ xs2.write(1); // This call is illegal.</code></pre>
           <div id=append class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3844"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L4010"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#append"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.append(y)</pre>
@@ -752,7 +752,7 @@ xs2.write(1); // This call is illegal.</code></pre>
           <div id=batch class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3000"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3111"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#batch"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.batch(n)</pre>
@@ -775,7 +775,7 @@ xs2.write(1); // This call is illegal.</code></pre>
           <div id=batchWithTimeOrCount class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3016"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3128"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#batchWithTimeOrCount"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.batchWithTimeOrCount(ms, n)</pre>
@@ -811,7 +811,7 @@ into arrays of a maximum length.</p>
           <div id=collect class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3951"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3487"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#collect"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.collect()</pre>
@@ -830,7 +830,7 @@ of accepting a callback and consuming the stream, it passes the value on.</p>
           <div id=compact class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L2707"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L2820"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#compact"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.compact()</pre>
@@ -893,7 +893,7 @@ like a 'through' stream, handling values as they are read.</p>
           <div id=debounce class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L4516"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L4686"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#debounce"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.debounce(ms)</pre>
@@ -938,7 +938,7 @@ _(function (push, next) {
           <div id=doto class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L2177"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L2182"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#doto"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.doto(f)</pre>
@@ -971,7 +971,7 @@ _([1, 2, 3]).doto(console.log)
           <div id=drop class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3259"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L3425"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#drop"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.drop(n)</pre>
@@ -1042,7 +1042,7 @@ transformed and put back onto the Stream as values.</p>
           <div id=filter class="doc-item">
             <div class="doc-heading">
               <ul class="links">
-                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L2508"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L2623"><i class="fi-pencil"></i> Source</a></li>
                 <li><a href="#filter"><i class="fi-link"></i> Link</a></li>
               </ul>
               <pre>Stream.filter(f)</pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,6 +99,7 @@
         <li><a href="#stopOnError">stopOnError</a></li>
         <li><a href="#take">take</a></li>
         <li><a href="#tap">tap</a></li>
+        <li><a href="#tapCollect">tapCollect</a></li>
         <li><a href="#throttle">throttle</a></li>
         <li><a href="#transduce">transduce</a></li>
         <li><a href="#uniq">uniq</a></li>
@@ -1886,6 +1887,29 @@ an Error is encountered.</p>
             </div>
 
             <p>An alias for the <a href="#doto">doto</a> method.</p>
+
+            <div class="doc-params-heading">Parameters</div>
+            <ul>
+                <li>
+                  <code>f</code>
+                   - <em>Function</em>
+                   - the function to apply
+                </li>
+            </ul>
+
+
+            <pre><code class="javascript">_([1, 2, 3]).tap(console.log)</code></pre>
+          </div>
+          <div id=tapCollect class="doc-item">
+            <div class="doc-heading">
+              <ul class="links">
+                <li><a href="https://github.com/caolan/highland/blob/3.0.0-beta.9/lib/index.js#L2290"><i class="fi-pencil"></i> Source</a></li>
+                <li><a href="#tap"><i class="fi-link"></i> Link</a></li>
+              </ul>
+              <pre>Stream.tapCollect(f)</pre>
+            </div>
+
+            <p>Similar to the <a href="#doto">doto</a> method with the exception that it consumes the stream and collects all values to be passed in to the function <cod>x</cod>.</p>
 
             <div class="doc-params-heading">Parameters</div>
             <ul>

--- a/lib/index.js
+++ b/lib/index.js
@@ -2288,6 +2288,34 @@ addMethod('doto', function (f) {
 });
 
 /**
+ * Creates a new Stream which collects all values and applies a function to the collected array from the source
+ * and re-emits the source values in a stream. Useful when you want to mutate the value or
+ * perform side effects and need all values to do so.
+ *
+ * @id doto
+ * @section Transforms
+ * @name Stream.tapCollect(f)
+ * @param {Function} f - the function to apply
+ * @api public
+ *
+ * var appended = _([[1], [2], [3], [4]]).tapCollect(function (x) {
+ *     x.push(1);
+ * });
+ *
+ * _([1, 2, 3]).tapCollect(console.log)
+ * // [1, 2, 3]
+ * // => 1, 2, 3
+ */
+
+addMethod('tapCollect', function (f) {
+    return this.collect().tap(function (x) {
+        f(x);
+        return x;
+    })
+        .flatten();
+});
+
+/**
  * An alias for the [doto](#doto) method.
  *
  * @id tap

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "highland",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "highland",
-  "version": "3.0.0-beta.9",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highland",
-  "version": "3.0.0-beta.9",
+  "version": "3.0.0",
   "description": "The high-level streams library",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highland",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The high-level streams library",
   "main": "lib/index.js",
   "files": [

--- a/test/test.js
+++ b/test/test.js
@@ -2995,6 +2995,17 @@ exports.subscribe = {
             })
             .subscribe();
     },
+    'consumes and collects the stream without any handlers': function (test) {
+        test.expect(1);
+        _([1, 2, 3])
+            .tapCollect(function (x) {
+                test.ok(x.length);
+                if (x.length === 3) {
+                    test.done();
+                }
+            })
+            .subscribe();
+    },
     'a subscription can be unsubscribed': function (test) {
         test.expect(1);
         var stream = _();


### PR DESCRIPTION
This is to add a method called `tapCollect()` to eliminate the need for some boilerplate chains.

If you have a method that needs the `.tap` capability but need a collected array of all stream values for the callback, then introducing the new method.

```javascript
_.([1, 2, 3])
    .collect()
    .tap(x => doSomething(x))
    .flatten();
```
This is alot of boilerplate that could be removed when all we need is just an operation in the middle of our stream chain on all values. The above now becomes...
```javascript
_.([1, 2, 3])
    .tapCollect(x => doSomething(x));
```

This came up for me when I had to write the former several times for a simple scenario of streaming values and then needing all values in the middle of a stream for a db call (nesting them in a SQL `WHERE IN (...)` statement).

I would write quite a bit because I needed to remove those rows but then keep the values for later data creation.
```javascript
_.([1, 2, 3])
    .collect()
    .tap(x => Model.destroy({ values: x }))
    .flatten();
```