### PR TITLE
Support async generators

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,6 +126,11 @@ function bindContext(fn, context) {
  * i.e., contains a method that returns an object that conforms to the iterator protocol. The stream will use the
  * iterator defined in the `Symbol.iterator` property of the iterable object to generate emitted values.
  *
+ * **Asynchronous Iterator -** Accepts an iterator produced by an ES8 [async generator function](https://github.com/tc39/proposal-async-iteration#async-generator-functions),
+ * yields all the values from the iterator by resolving its `next()` method and terminates when the
+ * iterator's done value returns true. If the iterator's `next()` method throws or rejects, the exception will be emitted as an error,
+ * and the stream will be ended with no further calls to `next()`.
+ *
  * @id _(source)
  * @section Stream Objects
  * @name _(source)
@@ -679,33 +684,42 @@ function promiseStream(StreamCtor, promise) {
 
 function iteratorStream(StreamCtor, it) {
     return new StreamCtor(function (push, next) {
-        var iterElem, iterErr;
+        function pushIt(iterElem) {
+            if (iterElem.done) {
+                if (!_.isUndefined(iterElem.value)) {
+                    // generators can return a final
+                    // value on completion using return
+                    // keyword otherwise value will be
+                    // undefined
+                    push(null, iterElem.value);
+                }
+                push(null, _.nil);
+            }
+            else {
+                push(null, iterElem.value);
+                next();
+            }
+        }
+
         try {
-            iterElem = it.next();
+            var iterElem = it.next();
+
+            if (_.isFunction(iterElem.then)) {
+                iterElem
+                    .then(pushIt)
+                    .catch(function(err) {
+                        push(err);
+                        push(null, _.nil);
+                    });
+            }
+            else {
+                pushIt(iterElem);
+            }
         }
         catch (err) {
-            iterErr = err;
-        }
-
-        if (iterErr) {
-            push(iterErr);
+            push(err);
             push(null, _.nil);
         }
-        else if (iterElem.done) {
-            if (!_.isUndefined(iterElem.value)) {
-                // generators can return a final
-                // value on completion using return
-                // keyword otherwise value will be
-                // undefined
-                push(null, iterElem.value);
-            }
-            push(null, _.nil);
-        }
-        else {
-            push(null, iterElem.value);
-            next();
-        }
-
     });
 }
 


### PR DESCRIPTION
Not sure if there's interest in landing this - I guess it's a question of whether you want to drop IE11 support or introduce babel or something, so there's two commits - one just uses async/await, but the grunt task fails. The other (most recent) uses Promise.resolve and the grunt task works.