### PR TITLE
mention merge* in parallel doc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3897,6 +3897,9 @@ addMethod('flatten', function () {
  * the results until they can be returned to the consumer in their original
  * order.
  *
+ * For parallelizing streams without less respect for ordering, see
+ * [merge](#merge) and [mergeWithLimit](#mergeWithLimit)
+ *
  * @id parallel
  * @section Higher-order Streams
  * @name Stream.parallel(n)


### PR DESCRIPTION
Wasted a good deal of my time trying to figure out why `parallel` was not performing as efficiently as I expected.

Hopefully this will save others from the same tar pit!