### PR TITLE
[#691] Propagate destroy from consumers to sources

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -483,6 +483,7 @@ function pipeReadable(xs, onFinish, stream) {
     xs.pipe(stream);
 
     // TODO: Replace with onDestroy in v3.
+    // ...although it appears `_destructors` are called `onEnd`, not just `onDestroy`?
     stream._destructors.push(unbind);
 
     function streamEndCb(error) {
@@ -495,12 +496,12 @@ function pipeReadable(xs, onFinish, stream) {
         }
 
         if (error == null || endOnError) {
-            unbind();
+            unbind(error);
             stream.end();
         }
     }
 
-    function unbind() {
+    function unbind(error) {
         if (unbound) {
             return;
         }
@@ -513,6 +514,16 @@ function pipeReadable(xs, onFinish, stream) {
 
         if (xs.unpipe) {
             xs.unpipe(stream);
+        }
+
+        // Destroy the wrapped `Readable` stream if it's not yet ended.
+        // i.e. this was ended externally, perhaps by a consumer.
+        // TODO: Use something other than `readableEnded` as it was introduced recently (Node v12.9.0)
+        if (!xs.readableEnded) {
+            // NOTE: Not sure whether `error` is necessary here as it'd only ever come from
+            // the unbind call in `streamEndCb` which originates from the `xs` in the
+            // first place, so it'd prob be able to handle itself?
+            xs.destroy(error);
         }
     }
 }
@@ -1327,6 +1338,8 @@ Stream.prototype.pipe = function (dest, options) {
  */
 
 Stream.prototype.destroy = function () {
+    var source = this.source;
+
     if (this.ended) {
         return;
     }
@@ -1336,6 +1349,10 @@ Stream.prototype.destroy = function () {
     }
 
     this._onEnd();
+
+    if (!this._is_observer && source) {
+        source.destroy();
+    }
 };
 
 /**
@@ -1618,7 +1635,7 @@ Stream.prototype.pull = function (f) {
  *
  * Only call this function on streams that were constructed with no source
  * (i.e., with `_()`).
-
+ 
  * @id write
  * @section Stream Objects
  * @name Stream.write(x)
@@ -1748,6 +1765,7 @@ Stream.prototype.fork = function () {
 
     var s = new Stream();
     s.id = 'fork:' + s.id;
+    // TODO: Could this just call into `this._addConsumer`?
     s.source = this;
     this._consumers.push(s);
     this._checkBackPressure();
@@ -2426,7 +2444,7 @@ var objectOnly = _.curry(function(strategy, x) {
  *      {breed: 'labrador', name: 'Rocky', age: 3},
  *      {breed: 'german-shepherd', name: 'Waffles', age: 9}
  *  ];
-
+ 
  *  _(dogs).pickBy(function (key, value) {
  *      return value > 4;
  *  }).toArray(function (xs) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1351,6 +1351,15 @@ Stream.prototype.destroy = function () {
     this._onEnd();
 
     if (!this._is_observer && source) {
+        // TODO: Should we only destroy the source if nothing else is consuming it, i.e. all sibling `_consumers` are already
+        // destroyed / ended?
+        // i.e.
+        // var s = _()
+        // var s1 = _().fork()
+        // var s2 = _().fork()
+        // s1.destroy() // s still alive
+        // s2.destroy() // s now destroyed
+        // and ignore `_observers`?
         source.destroy();
     }
 };
@@ -1765,7 +1774,6 @@ Stream.prototype.fork = function () {
 
     var s = new Stream();
     s.id = 'fork:' + s.id;
-    // TODO: Could this just call into `this._addConsumer`?
     s.source = this;
     this._consumers.push(s);
     this._checkBackPressure();


### PR DESCRIPTION
@vqvu I know you've indicated that making this work is difficult but I think it's a really important feature for usage with Node streams, so thought I'd give it a stab to try and understand the issue better.

There's sure to be holes in my implementation as I'm v. new to highland so don't have a complete understanding of the library and I've largely been considering my specific use-case of piping to a `Node.ServerResponse`.

Currently this is what I've done:

1. When a highland `Stream` is destroyed, also destroy the underlying node `Readable` stream.

This solves this problem:

```js
const { pipeline } = require('pipeline');
pipeline(_(nodeReadableStream), nodeWritableStream, (ex) => {
  console.log('Finished', ex); 
})
nodeWritableStream.destroy();
// `nodeReadableStream` is destroyed, allowing it to clean up any connections / stop filling up it's buffer etc.
```

2. Propagate consumer destroy to source.

This solves this problem:

```js
const { pipeline } = require('pipeline');
pipeline(_(nodeReadableStream).map((chunk) => JSON.stringify(chunk)), nodeWritableStream, (ex) => {
  console.log('Finished', ex);
})
nodeWritableStream.destroy();
// `nodeReadableStream` is destroyed, allowing it to clean up any connections / stop filling up it's buffer etc.
```

I think the above is where the difficulty comes in due to `fork` & `observe`. I've currently taken the stance that `observe` never propagates destroy and `fork` always propagates destroy, although I think `fork` should probably actually only propagate destroy if all siblings have ended too, i.e. there are no more consumers.

Additionally, if this could be made to work -- I imagine it'd make sense for it to be opt in for cases where you do not want to destroy the readable, e.g.

```js
const _(nodeReadableStream).destroyOnError().map(() => { ... })
```

Anyway, I understand if you're not interested as it sounds like you've been down this path before but happy to help out if you think this can be made to work.